### PR TITLE
Fix warning about deprecated `ruff` usage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ fmt         = ["isort .",
                "pylint --output-format=colorized -j 0 src"]
 verify      = ["black --check .",
                "isort . --check-only",
-               "ruff .",
+               "ruff check .",
                "mypy .",
                "pylint --output-format=colorized -j 0 src"]
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary -->

Fixes following warning

```
cmd [3] | ruff .
warning: `ruff <path>` is deprecated. Use `ruff check <path>` instead.
```

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #..

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
