### PR TITLE
Correct handling of Decimal, Short and Byte types

### DIFF
--- a/src/databricks/labs/dqx/profiler/common.py
+++ b/src/databricks/labs/dqx/profiler/common.py
@@ -1,5 +1,6 @@
 import datetime
 import re
+from decimal import Decimal
 from typing import Any
 
 
@@ -17,7 +18,7 @@ def val_to_str(value: Any, include_sql_quotes: bool = True):
     if isinstance(value, datetime.date):
         return f"{quote}{value.isoformat()}{quote}"
 
-    if isinstance(value, (int, float)):
+    if isinstance(value, (int, float, Decimal)):
         return str(value)
 
     escaped_value = re.sub(r"(['\\])", r"\\\1", str(value))

--- a/tests/integration/test_dlt_rules_generator.py
+++ b/tests/integration/test_dlt_rules_generator.py
@@ -17,6 +17,7 @@ def test_generate_dlt_sql_expect(ws):
         "CONSTRAINT rate_code_id_min_max EXPECT (rate_code_id >= 1 and rate_code_id <= 265)",
         "CONSTRAINT product_launch_date_min_max EXPECT (product_launch_date >= '2020-01-01')",
         "CONSTRAINT product_expiry_ts_min_max EXPECT (product_expiry_ts <= '2020-01-01T00:00:00.000000')",
+        "CONSTRAINT d1_min_max EXPECT (d1 >= 1.23 and d1 <= 333323.00)",
     ]
     assert expectations == expected
 
@@ -31,6 +32,7 @@ def test_generate_dlt_sql_drop(ws):
         "CONSTRAINT rate_code_id_min_max EXPECT (rate_code_id >= 1 and rate_code_id <= 265) ON VIOLATION DROP ROW",
         "CONSTRAINT product_launch_date_min_max EXPECT (product_launch_date >= '2020-01-01') ON VIOLATION DROP ROW",
         "CONSTRAINT product_expiry_ts_min_max EXPECT (product_expiry_ts <= '2020-01-01T00:00:00.000000') ON VIOLATION DROP ROW",
+        "CONSTRAINT d1_min_max EXPECT (d1 >= 1.23 and d1 <= 333323.00) ON VIOLATION DROP ROW",
     ]
     assert expectations == expected
 
@@ -45,6 +47,7 @@ def test_generate_dlt_sql_fail(ws):
         "CONSTRAINT rate_code_id_min_max EXPECT (rate_code_id >= 1 and rate_code_id <= 265) ON VIOLATION FAIL UPDATE",
         "CONSTRAINT product_launch_date_min_max EXPECT (product_launch_date >= '2020-01-01') ON VIOLATION FAIL UPDATE",
         "CONSTRAINT product_expiry_ts_min_max EXPECT (product_expiry_ts <= '2020-01-01T00:00:00.000000') ON VIOLATION FAIL UPDATE",
+        "CONSTRAINT d1_min_max EXPECT (d1 >= 1.23 and d1 <= 333323.00) ON VIOLATION FAIL UPDATE",
     ]
     assert expectations == expected
 
@@ -53,7 +56,7 @@ def test_generate_dlt_python_expect(ws):
     generator = DQDltGenerator(ws)
     expectations = generator.generate_dlt_rules(test_rules, language="Python")
     expected = """@dlt.expect_all(
-{"vendor_id_is_not_null": "vendor_id is not null", "vendor_id_is_in": "vendor_id in ('1', '4', '2')", "vendor_id_is_not_null_or_empty": "vendor_id is not null and trim(vendor_id) <> ''", "rate_code_id_min_max": "rate_code_id >= 1 and rate_code_id <= 265", "product_launch_date_min_max": "product_launch_date >= '2020-01-01'", "product_expiry_ts_min_max": "product_expiry_ts <= '2020-01-01T00:00:00.000000'"}
+{"vendor_id_is_not_null": "vendor_id is not null", "vendor_id_is_in": "vendor_id in ('1', '4', '2')", "vendor_id_is_not_null_or_empty": "vendor_id is not null and trim(vendor_id) <> ''", "rate_code_id_min_max": "rate_code_id >= 1 and rate_code_id <= 265", "product_launch_date_min_max": "product_launch_date >= '2020-01-01'", "product_expiry_ts_min_max": "product_expiry_ts <= '2020-01-01T00:00:00.000000'", "d1_min_max": "d1 >= 1.23 and d1 <= 333323.00"}
 )"""
     assert expectations == expected
 
@@ -62,7 +65,7 @@ def test_generate_dlt_python_drop(ws):
     generator = DQDltGenerator(ws)
     expectations = generator.generate_dlt_rules(test_rules, language="Python", action="drop")
     expected = """@dlt.expect_all_or_drop(
-{"vendor_id_is_not_null": "vendor_id is not null", "vendor_id_is_in": "vendor_id in ('1', '4', '2')", "vendor_id_is_not_null_or_empty": "vendor_id is not null and trim(vendor_id) <> ''", "rate_code_id_min_max": "rate_code_id >= 1 and rate_code_id <= 265", "product_launch_date_min_max": "product_launch_date >= '2020-01-01'", "product_expiry_ts_min_max": "product_expiry_ts <= '2020-01-01T00:00:00.000000'"}
+{"vendor_id_is_not_null": "vendor_id is not null", "vendor_id_is_in": "vendor_id in ('1', '4', '2')", "vendor_id_is_not_null_or_empty": "vendor_id is not null and trim(vendor_id) <> ''", "rate_code_id_min_max": "rate_code_id >= 1 and rate_code_id <= 265", "product_launch_date_min_max": "product_launch_date >= '2020-01-01'", "product_expiry_ts_min_max": "product_expiry_ts <= '2020-01-01T00:00:00.000000'", "d1_min_max": "d1 >= 1.23 and d1 <= 333323.00"}
 )"""
     assert expectations == expected
 
@@ -71,7 +74,7 @@ def test_generate_dlt_python_fail(ws):
     generator = DQDltGenerator(ws)
     expectations = generator.generate_dlt_rules(test_rules, language="Python", action="fail")
     expected = """@dlt.expect_all_or_fail(
-{"vendor_id_is_not_null": "vendor_id is not null", "vendor_id_is_in": "vendor_id in ('1', '4', '2')", "vendor_id_is_not_null_or_empty": "vendor_id is not null and trim(vendor_id) <> ''", "rate_code_id_min_max": "rate_code_id >= 1 and rate_code_id <= 265", "product_launch_date_min_max": "product_launch_date >= '2020-01-01'", "product_expiry_ts_min_max": "product_expiry_ts <= '2020-01-01T00:00:00.000000'"}
+{"vendor_id_is_not_null": "vendor_id is not null", "vendor_id_is_in": "vendor_id in ('1', '4', '2')", "vendor_id_is_not_null_or_empty": "vendor_id is not null and trim(vendor_id) <> ''", "rate_code_id_min_max": "rate_code_id >= 1 and rate_code_id <= 265", "product_launch_date_min_max": "product_launch_date >= '2020-01-01'", "product_expiry_ts_min_max": "product_expiry_ts <= '2020-01-01T00:00:00.000000'", "d1_min_max": "d1 >= 1.23 and d1 <= 333323.00"}
 )"""
     assert expectations == expected
 

--- a/tests/integration/test_profiler.py
+++ b/tests/integration/test_profiler.py
@@ -1,4 +1,6 @@
 from datetime import date, datetime
+from decimal import Decimal
+
 import pyspark.sql.types as T
 from databricks.labs.dqx.profiler.profiler import DQProfiler, DQProfile
 
@@ -7,6 +9,7 @@ def test_profiler(spark, ws):
     inp_schema = T.StructType(
         [
             T.StructField("t1", T.IntegerType()),
+            T.StructField("d1", T.DecimalType(10, 2)),
             T.StructField("t2", T.StringType()),
             T.StructField(
                 "s1",
@@ -26,6 +29,7 @@ def test_profiler(spark, ws):
         [
             [
                 1,
+                Decimal("1.23"),
                 " test ",
                 {
                     "ns1": datetime.fromisoformat("2023-01-08T10:00:11+00:00"),
@@ -34,6 +38,7 @@ def test_profiler(spark, ws):
             ],
             [
                 2,
+                Decimal("2.41"),
                 "test2",
                 {
                     "ns1": datetime.fromisoformat("2023-01-07T10:00:11+00:00"),
@@ -42,6 +47,7 @@ def test_profiler(spark, ws):
             ],
             [
                 3,
+                Decimal("333323.0"),
                 None,
                 {
                     "ns1": datetime.fromisoformat("2023-01-06T10:00:11+00:00"),
@@ -59,6 +65,13 @@ def test_profiler(spark, ws):
         DQProfile(name="is_not_null", column="t1", description=None, parameters=None),
         DQProfile(
             name="min_max", column="t1", description="Real min/max values were used", parameters={"min": 1, "max": 3}
+        ),
+        DQProfile(name='is_not_null', column='d1', description=None, parameters=None),
+        DQProfile(
+            name='min_max',
+            column='d1',
+            description='Real min/max values were used',
+            parameters={'max': Decimal('333323.00'), 'min': Decimal('1.23')},
         ),
         DQProfile(name='is_not_null_or_empty', column='t2', description=None, parameters={'trim_strings': True}),
         DQProfile(name="is_not_null", column="s1.ns1", description=None, parameters=None),

--- a/tests/integration/test_rules_generator.py
+++ b/tests/integration/test_rules_generator.py
@@ -1,4 +1,5 @@
 import datetime
+from decimal import Decimal
 
 from databricks.labs.dqx.profiler.generator import DQGenerator
 from databricks.labs.dqx.profiler.profiler import DQProfile
@@ -28,6 +29,12 @@ test_rules = [
         description="Real min/max values were used",
     ),
     DQProfile(name="is_random", column="vendor_id", parameters={"in": ["1", "4", "2"]}),
+    DQProfile(
+        name='min_max',
+        column='d1',
+        description='Real min/max values were used',
+        parameters={'max': Decimal('333323.00'), 'min': Decimal('1.23')},
+    ),
 ]
 
 

--- a/tests/unit/test_profiler_common.py
+++ b/tests/unit/test_profiler_common.py
@@ -1,4 +1,6 @@
 import datetime
+from decimal import Decimal
+
 from databricks.labs.dqx.profiler.common import val_maybe_to_str, val_to_str
 
 
@@ -18,6 +20,9 @@ def test_val_to_str():
 
     # Test with float
     assert val_to_str(123.45) == "123.45"
+
+    # Test with Decimal
+    assert val_to_str(Decimal("123.45")) == "123.45"
 
     # Test with string
     assert val_to_str("test") == "'test'"


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary -->

We now support handling of min/max for Decimal type in the profiler.

I was need to move some logic into a separate function to decrease complexity of the function.


### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #97

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [x] added unit tests
- [x] added integration tests
