### PR TITLE
Support datetime arguments for column range functions

### DIFF
--- a/src/databricks/labs/dqx/col_functions.py
+++ b/src/databricks/labs/dqx/col_functions.py
@@ -1,3 +1,4 @@
+import datetime
 import re
 
 import pyspark.sql.functions as F
@@ -245,14 +246,23 @@ def not_in_near_future(col_name: str, offset: int = 0, curr_timestamp: Column | 
     )
 
 
-def not_less_than(col_name: str, limit: int) -> Column:
+def not_less_than(col_name: str, limit: int | datetime.date | datetime.datetime) -> Column:
     """Creates a condition column that checks if a value is less than specified limit.
 
     :param col_name: column name
     :param limit: limit to use in the condition
     :return: new Column
     """
-    condition = F.col(col_name) < limit
+    if isinstance(limit, int):
+        limit_expr = F.lit(limit)
+    elif isinstance(limit, datetime.date):
+        limit_expr = F.to_date(F.lit(str(limit)))
+    elif isinstance(limit, datetime.datetime):
+        limit_expr = F.to_timestamp(F.lit(str(limit)))
+    else:
+        raise TypeError('limit must be of type int, datetime.date, or datetime.datetime')
+
+    condition = F.col(col_name) < limit_expr
 
     return make_condition(
         condition,
@@ -261,14 +271,23 @@ def not_less_than(col_name: str, limit: int) -> Column:
     )
 
 
-def not_greater_than(col_name: str, limit: int) -> Column:
+def not_greater_than(col_name: str, limit: int | datetime.date | datetime.datetime) -> Column:
     """Creates a condition column that checks if a value is greater than specified limit.
 
     :param col_name: column name
     :param limit: limit to use in the condition
     :return: new Column
     """
-    condition = F.col(col_name) > limit
+    if isinstance(limit, int):
+        limit_expr = F.lit(limit)
+    elif isinstance(limit, datetime.date):
+        limit_expr = F.to_date(F.lit(str(limit)))
+    elif isinstance(limit, datetime.datetime):
+        limit_expr = F.to_timestamp(F.lit(str(limit)))
+    else:
+        raise TypeError('limit must be of type int, datetime.date, or datetime.datetime')
+
+    condition = F.col(col_name) < limit_expr
 
     return make_condition(
         condition,
@@ -277,7 +296,11 @@ def not_greater_than(col_name: str, limit: int) -> Column:
     )
 
 
-def is_in_range(col_name: str, min_limit: int, max_limit: int) -> Column:
+def is_in_range(
+    col_name: str,
+    min_limit: int | datetime.date | datetime.datetime,
+    max_limit: int | datetime.date | datetime.datetime,
+) -> Column:
     """Creates a condition column that checks if a value is smaller than min limit or greater than max limit.
 
     :param col_name: column name
@@ -285,7 +308,19 @@ def is_in_range(col_name: str, min_limit: int, max_limit: int) -> Column:
     :param max_limit: max limit
     :return: new Column
     """
-    condition = (F.col(col_name) < min_limit) | (F.col(col_name) > max_limit)
+    if isinstance(min_limit, int):
+        min_limit_expr = F.lit(min_limit)
+        max_limit_expr = F.lit(max_limit)
+    elif isinstance(min_limit, datetime.date):
+        min_limit_expr = F.to_date(F.lit(str(min_limit)))
+        max_limit_expr = F.to_date(F.lit(str(max_limit)))
+    elif isinstance(min_limit, datetime.datetime):
+        min_limit_expr = F.to_timestamp(F.lit(str(min_limit)))
+        max_limit_expr = F.to_timestamp(F.lit(str(max_limit)))
+    else:
+        raise TypeError('min_limit and max_limit must be of type int, datetime.date, or datetime.datetime')
+
+    condition = (F.col(col_name) < min_limit_expr) | (F.col(col_name) > max_limit_expr)
 
     return make_condition(
         condition,
@@ -303,7 +338,11 @@ def is_in_range(col_name: str, min_limit: int, max_limit: int) -> Column:
     )
 
 
-def is_not_in_range(col_name: str, min_limit: int, max_limit: int) -> Column:
+def is_not_in_range(
+    col_name: str,
+    min_limit: int | datetime.date | datetime.datetime,
+    max_limit: int | datetime.date | datetime.datetime,
+) -> Column:
     """Creates a condition column that checks if a value is within min and max limits.
 
     :param col_name: column name
@@ -311,7 +350,19 @@ def is_not_in_range(col_name: str, min_limit: int, max_limit: int) -> Column:
     :param max_limit: max limit
     :return: new Column
     """
-    condition = (F.col(col_name) > min_limit) & (F.col(col_name) < max_limit)
+    if isinstance(min_limit, int):
+        min_limit_expr = F.lit(min_limit)
+        max_limit_expr = F.lit(max_limit)
+    elif isinstance(min_limit, datetime.date):
+        min_limit_expr = F.to_date(F.lit(str(min_limit)))
+        max_limit_expr = F.to_date(F.lit(str(max_limit)))
+    elif isinstance(min_limit, datetime.datetime):
+        min_limit_expr = F.to_timestamp(F.lit(str(min_limit)))
+        max_limit_expr = F.to_timestamp(F.lit(str(max_limit)))
+    else:
+        raise TypeError('min_limit and max_limit must be of type int, datetime.date, or datetime.datetime')
+
+    condition = (F.col(col_name) > min_limit_expr) & (F.col(col_name) < max_limit_expr)
 
     return make_condition(
         condition,

--- a/src/databricks/labs/dqx/col_functions.py
+++ b/src/databricks/labs/dqx/col_functions.py
@@ -253,15 +253,7 @@ def not_less_than(col_name: str, limit: int | datetime.date | datetime.datetime)
     :param limit: limit to use in the condition
     :return: new Column
     """
-    if isinstance(limit, int):
-        limit_expr = F.lit(limit)
-    elif isinstance(limit, datetime.date):
-        limit_expr = F.to_date(F.lit(str(limit)))
-    elif isinstance(limit, datetime.datetime):
-        limit_expr = F.to_timestamp(F.lit(str(limit)))
-    else:
-        raise TypeError('limit must be of type int, datetime.date, or datetime.datetime')
-
+    limit_expr = F.lit(limit)
     condition = F.col(col_name) < limit_expr
 
     return make_condition(
@@ -278,15 +270,7 @@ def not_greater_than(col_name: str, limit: int | datetime.date | datetime.dateti
     :param limit: limit to use in the condition
     :return: new Column
     """
-    if isinstance(limit, int):
-        limit_expr = F.lit(limit)
-    elif isinstance(limit, datetime.date):
-        limit_expr = F.to_date(F.lit(str(limit)))
-    elif isinstance(limit, datetime.datetime):
-        limit_expr = F.to_timestamp(F.lit(str(limit)))
-    else:
-        raise TypeError('limit must be of type int, datetime.date, or datetime.datetime')
-
+    limit_expr = F.lit(limit)
     condition = F.col(col_name) < limit_expr
 
     return make_condition(
@@ -308,18 +292,8 @@ def is_in_range(
     :param max_limit: max limit
     :return: new Column
     """
-    if isinstance(min_limit, int):
-        min_limit_expr = F.lit(min_limit)
-        max_limit_expr = F.lit(max_limit)
-    elif isinstance(min_limit, datetime.date):
-        min_limit_expr = F.to_date(F.lit(str(min_limit)))
-        max_limit_expr = F.to_date(F.lit(str(max_limit)))
-    elif isinstance(min_limit, datetime.datetime):
-        min_limit_expr = F.to_timestamp(F.lit(str(min_limit)))
-        max_limit_expr = F.to_timestamp(F.lit(str(max_limit)))
-    else:
-        raise TypeError('min_limit and max_limit must be of type int, datetime.date, or datetime.datetime')
-
+    min_limit_expr = F.lit(min_limit)
+    max_limit_expr = F.lit(max_limit)
     condition = (F.col(col_name) < min_limit_expr) | (F.col(col_name) > max_limit_expr)
 
     return make_condition(
@@ -350,18 +324,8 @@ def is_not_in_range(
     :param max_limit: max limit
     :return: new Column
     """
-    if isinstance(min_limit, int):
-        min_limit_expr = F.lit(min_limit)
-        max_limit_expr = F.lit(max_limit)
-    elif isinstance(min_limit, datetime.date):
-        min_limit_expr = F.to_date(F.lit(str(min_limit)))
-        max_limit_expr = F.to_date(F.lit(str(max_limit)))
-    elif isinstance(min_limit, datetime.datetime):
-        min_limit_expr = F.to_timestamp(F.lit(str(min_limit)))
-        max_limit_expr = F.to_timestamp(F.lit(str(max_limit)))
-    else:
-        raise TypeError('min_limit and max_limit must be of type int, datetime.date, or datetime.datetime')
-
+    min_limit_expr = F.lit(min_limit)
+    max_limit_expr = F.lit(max_limit)
     condition = (F.col(col_name) > min_limit_expr) & (F.col(col_name) < max_limit_expr)
 
     return make_condition(

--- a/src/databricks/labs/dqx/col_functions.py
+++ b/src/databricks/labs/dqx/col_functions.py
@@ -271,7 +271,7 @@ def not_greater_than(col_name: str, limit: int | datetime.date | datetime.dateti
     :return: new Column
     """
     limit_expr = F.lit(limit)
-    condition = F.col(col_name) < limit_expr
+    condition = F.col(col_name) > limit_expr
 
     return make_condition(
         condition,

--- a/tests/integration/test_functions.py
+++ b/tests/integration/test_functions.py
@@ -269,7 +269,7 @@ def test_col_not_greater_than(spark):
         not_greater_than("c", datetime(2025, 1, 1)),
     )
 
-    checked_schema = "a_greater_than_limit: string", "b_greater_than_limit: string", "c_greater_than_limit: string"
+    checked_schema = "a_greater_than_limit: string, b_greater_than_limit: string, c_greater_than_limit: string"
     expected = spark.createDataFrame(
         [
             [None, None, None],
@@ -314,7 +314,7 @@ def test_col_is_in_range(spark):
             [
                 "Value 0 not in range: [ 1 , 3 ]",
                 "Value 2024-12-01 not in range: [ 2025-01-01 , 2025-03-01 ]",
-                "value 2024-12-01 00:00:00 not in range: [ 2025-01-01 00:00:00 , 2025-03-01 00:00:00 ]",
+                "Value 2024-12-01 00:00:00 not in range: [ 2025-01-01 00:00:00 , 2025-03-01 00:00:00 ]",
             ],
             [None, None, None],
             [None, None, None],
@@ -322,7 +322,7 @@ def test_col_is_in_range(spark):
             [
                 "Value 4 not in range: [ 1 , 3 ]",
                 "Value 2025-04-01 not in range: [ 2025-01-01 , 2025-03-01 ]",
-                "value 2025-04-01 00:00:00 not in range: [ 2025-01-01 00:00:00 , 2025-03-01 00:00:00 ]",
+                "Value 2025-04-01 00:00:00 not in range: [ 2025-01-01 00:00:00 , 2025-03-01 00:00:00 ]",
             ],
             [None, None, None],
         ],
@@ -336,9 +336,9 @@ def test_col_is_not_in_range(spark):
     schema_num = "a: int, b: date, c: timestamp"
     test_df = spark.createDataFrame(
         [
-            [1, datetime(2024, 12, 1).date(), datetime(2024, 12, 1)],
+            [1, datetime(2025, 1, 1).date(), datetime(2024, 1, 1)],
             [2, datetime(2025, 2, 1).date(), datetime(2025, 2, 1)],
-            [3, datetime(2025, 4, 1).date(), datetime(2025, 4, 1)],
+            [3, datetime(2025, 3, 1).date(), datetime(2025, 3, 1)],
             [None, None, None],
         ],
         schema_num,

--- a/tests/integration/test_functions.py
+++ b/tests/integration/test_functions.py
@@ -336,9 +336,9 @@ def test_col_is_not_in_range(spark):
     schema_num = "a: int, b: date, c: timestamp"
     test_df = spark.createDataFrame(
         [
-            [1, datetime(2025, 1, 1).date(), datetime(2025, 1, 1)],
+            [1, datetime(2024, 12, 1).date(), datetime(2024, 12, 1)],
             [2, datetime(2025, 2, 1).date(), datetime(2025, 2, 1)],
-            [3, datetime(2025, 3, 1).date(), datetime(2025, 3, 1)],
+            [3, datetime(2025, 4, 1).date(), datetime(2025, 4, 1)],
             [None, None, None],
         ],
         schema_num,

--- a/tests/integration/test_functions.py
+++ b/tests/integration/test_functions.py
@@ -9,7 +9,6 @@ from databricks.labs.dqx.col_functions import (
     is_not_null_and_not_empty,
     is_older_than_col2_for_n_days,
     is_older_than_n_days,
-    not_greater_than,
     not_in_future,
     not_in_near_future,
     not_less_than,
@@ -219,38 +218,103 @@ def test_is_col_older_than_n_days_cur(spark):
 
 
 def test_col_not_less_than(spark):
-    schema_num = "a: int"
-    test_df = spark.createDataFrame([[1], [2], [None]], schema_num)
+    schema_num = "a: int, b: date, c: timestamp"
+    test_df = spark.createDataFrame(
+        [[1, "2025-01-01", "2025-01-01 00:00:00"], [2, "2025-02-01", "2025-02-01 00:00:00"], [None, None, None]],
+        schema_num,
+    )
 
-    actual = test_df.select(not_less_than("a", 2))
+    actual = test_df.select(
+        not_less_than("a", 2),
+        not_less_than("b", datetime(2025, 2, 1).date()),
+        not_less_than("c", datetime(2025, 2, 1)),
+    )
 
-    checked_schema = "a_less_than_limit: string"
-    expected = spark.createDataFrame([["Value 1 is less than limit: 2"], [None], [None]], checked_schema)
+    checked_schema = "a_less_than_limit: string, b_less_than_limit: string, c_less_than_limit: string"
+    expected = spark.createDataFrame(
+        [
+            [
+                "Value 1 is less than limit: 2",
+                "Value '2025-01-01' is less than limit: '2025-02-01'",
+                "Value '2025-01-01 00:00:00' is less than limit: '2025-02-01 00:00:00'",
+            ],
+            [None, None, None],
+            [None, None, None],
+        ],
+        checked_schema,
+    )
 
     assert_df_equality(actual, expected, ignore_nullable=True)
 
 
 def test_col_not_greater_than(spark):
-    schema_num = "a: int"
-    test_df = spark.createDataFrame([[1], [2], [None]], schema_num)
+    schema_num = "a: int, b: date, c: timestamp"
+    test_df = spark.createDataFrame(
+        [[1, "2025-01-01", "2025-01-01 00:00:00"], [2, "2025-02-01", "2025-02-01 00:00:00"], [None, None, None]],
+        schema_num,
+    )
 
-    actual = test_df.select(not_greater_than("a", 1))
+    actual = test_df.select(
+        not_less_than("a", 1), not_less_than("b", datetime(2025, 1, 1).date()), not_less_than("c", datetime(2025, 1, 1))
+    )
 
-    checked_schema = "a_greater_than_limit: string"
-    expected = spark.createDataFrame([[None], ["Value 2 is greater than limit: 1"], [None]], checked_schema)
+    checked_schema = "a_greater_than_limit: string", "b_greater_than_limit: string", "c_greater_than_limit: string"
+    expected = spark.createDataFrame(
+        [
+            [None, None, None],
+            [
+                "Value 2 is greater than limit: 1",
+                "Value '2025-02-01' is greater than limit: '2025-01-01'",
+                "Value '2025-02-01 00:00:00' is greater than limit: '2025-01-01 00:00:00'",
+            ],
+            [None, None, None],
+        ],
+        checked_schema,
+    )
 
     assert_df_equality(actual, expected, ignore_nullable=True)
 
 
 def test_col_is_in_range(spark):
-    schema_num = "a: int"
-    test_df = spark.createDataFrame([[0], [1], [2], [3], [4], [None]], schema_num)
+    schema_num = "a: int, b: date, c: timestamp"
+    test_df = spark.createDataFrame(
+        [
+            [0, "2024-12-01", "2024-12-01 00:00:00"],
+            [1, "2025-01-01", "2025-01-01 00:00:00"],
+            [2, "2025-02-01", "2025-02-01 00:00:00"],
+            [3, "2025-03-01", "2025-03-01 00:00:00"],
+            [4, "2025-04-01", "2025-04-01 00:00:00"],
+            [None, None, None],
+        ],
+        schema_num,
+    )
 
-    actual = test_df.select(is_in_range("a", 1, 3))
+    start_date = datetime(2025, 1, 1)
+    end_date = datetime(2025, 3, 1)
+    actual = test_df.select(
+        is_in_range("a", 1, 3),
+        is_in_range("b", start_date.date(), end_date.date()),
+        is_in_range("c", start_date, end_date),
+    )
 
-    checked_schema = "a_not_in_range: string"
+    checked_schema = "a_not_in_range: string, b_not_in_range: string, c_not_in_range: string"
     expected = spark.createDataFrame(
-        [["Value 0 not in range: [ 1 , 3 ]"], [None], [None], [None], ["Value 4 not in range: [ 1 , 3 ]"], [None]],
+        [
+            [
+                "Value 0 not in range: [ 1 , 3 ]",
+                "Value '2025-01-01' not in range: [ '2025-01-01' , '2025-03-01' ]",
+                "value '2025-01-01 00:00:00 not in range: [ '2025-01-01 00:00:00' , '2025-03-01 00:00:00'",
+            ],
+            [None, None, None],
+            [None, None, None],
+            [None, None, None],
+            [
+                "Value 4 not in range: [ 1 , 3 ]",
+                "Value '2025-04-01' not in range: [ '2025-01-01' , '2025-03-01' ]",
+                "value '2025-04-01 00:00:00 not in range: [ '2025-01-01 00:00:00' , '2025-03-01 00:00:00'",
+            ],
+            [None, None, None],
+        ],
         checked_schema,
     )
 
@@ -258,13 +322,39 @@ def test_col_is_in_range(spark):
 
 
 def test_col_is_not_in_range(spark):
-    schema_num = "a: int"
-    test_df = spark.createDataFrame([[1], [2], [3], [None]], schema_num)
+    schema_num = "a: int, b: date, c: timestamp"
+    test_df = spark.createDataFrame(
+        [
+            [1, "2025-01-01", "2025-01-01 00:00:00"],
+            [2, "2025-02-01", "2025-02-01 00:00:00"],
+            [3, "2025-03-01", "2025-03-01 00:00:00"],
+            [None, None, None],
+        ],
+        schema_num,
+    )
 
-    actual = test_df.select(is_not_in_range("a", 1, 3))
+    start_date = datetime(2025, 1, 1)
+    end_date = datetime(2025, 3, 1)
+    actual = test_df.select(
+        is_not_in_range("a", 1, 3),
+        is_not_in_range("b", start_date.date(), end_date.date()),
+        is_not_in_range("c", start_date, end_date),
+    )
 
-    checked_schema = "a_in_range: string"
-    expected = spark.createDataFrame([[None], ["Value 2 in range: [ 1 , 3 ]"], [None], [None]], checked_schema)
+    checked_schema = "a_in_range: string, b_in_range: string, c_in_range: string"
+    expected = spark.createDataFrame(
+        [
+            [None, None, None],
+            [
+                "Value 2 in range: [ 1 , 3 ]",
+                "Value '2025-02-01' in range: [ '2025-01-01' , '2025-03-01' ]",
+                "Value '2025-02-01 00:00:00' in range: [ '2025-01-01 00:00:00' , '2025-03-01 00:00:00' ]",
+            ],
+            [None, None, None],
+            [None, None, None],
+        ],
+        checked_schema,
+    )
 
     assert_df_equality(actual, expected, ignore_nullable=True)
 

--- a/tests/integration/test_functions.py
+++ b/tests/integration/test_functions.py
@@ -235,8 +235,8 @@ def test_col_not_less_than(spark):
         [
             [
                 "Value 1 is less than limit: 2",
-                "Value '2025-01-01' is less than limit: '2025-02-01'",
-                "Value '2025-01-01 00:00:00' is less than limit: '2025-02-01 00:00:00'",
+                "Value 2025-01-01 is less than limit: 2025-02-01",
+                "Value 2025-01-01 00:00:00 is less than limit: 2025-02-01 00:00:00",
             ],
             [None, None, None],
             [None, None, None],
@@ -264,8 +264,8 @@ def test_col_not_greater_than(spark):
             [None, None, None],
             [
                 "Value 2 is greater than limit: 1",
-                "Value '2025-02-01' is greater than limit: '2025-01-01'",
-                "Value '2025-02-01 00:00:00' is greater than limit: '2025-01-01 00:00:00'",
+                "Value 2025-02-01 is greater than limit: 2025-01-01",
+                "Value 2025-02-01 00:00:00 is greater than limit: 2025-01-01 00:00:00",
             ],
             [None, None, None],
         ],
@@ -302,16 +302,16 @@ def test_col_is_in_range(spark):
         [
             [
                 "Value 0 not in range: [ 1 , 3 ]",
-                "Value '2025-01-01' not in range: [ '2025-01-01' , '2025-03-01' ]",
-                "value '2025-01-01 00:00:00 not in range: [ '2025-01-01 00:00:00' , '2025-03-01 00:00:00'",
+                "Value 2025-01-01 not in range: [ 2025-01-01 , 2025-03-01 ]",
+                "value 2025-01-01 00:00:00 not in range: [ 2025-01-01 00:00:00 , 2025-03-01 00:00:00 ]",
             ],
             [None, None, None],
             [None, None, None],
             [None, None, None],
             [
                 "Value 4 not in range: [ 1 , 3 ]",
-                "Value '2025-04-01' not in range: [ '2025-01-01' , '2025-03-01' ]",
-                "value '2025-04-01 00:00:00 not in range: [ '2025-01-01 00:00:00' , '2025-03-01 00:00:00'",
+                "Value 2025-04-01 not in range: [ 2025-01-01 , 2025-03-01 ]",
+                "value 2025-04-01 00:00:00 not in range: [ 2025-01-01 00:00:00 , 2025-03-01 00:00:00 ]",
             ],
             [None, None, None],
         ],
@@ -347,8 +347,8 @@ def test_col_is_not_in_range(spark):
             [None, None, None],
             [
                 "Value 2 in range: [ 1 , 3 ]",
-                "Value '2025-02-01' in range: [ '2025-01-01' , '2025-03-01' ]",
-                "Value '2025-02-01 00:00:00' in range: [ '2025-01-01 00:00:00' , '2025-03-01 00:00:00' ]",
+                "Value 2025-02-01 in range: [ 2025-01-01 , 2025-03-01 ]",
+                "Value 2025-02-01 00:00:00 in range: [ 2025-01-01 00:00:00 , 2025-03-01 00:00:00 ]",
             ],
             [None, None, None],
             [None, None, None],

--- a/tests/integration/test_functions.py
+++ b/tests/integration/test_functions.py
@@ -220,7 +220,11 @@ def test_is_col_older_than_n_days_cur(spark):
 def test_col_not_less_than(spark):
     schema_num = "a: int, b: date, c: timestamp"
     test_df = spark.createDataFrame(
-        [[1, "2025-01-01", "2025-01-01 00:00:00"], [2, "2025-02-01", "2025-02-01 00:00:00"], [None, None, None]],
+        [
+            [1, datetime(2025, 1, 1).date(), datetime(2025, 1, 1)],
+            [2, datetime(2025, 2, 1).date(), datetime(2025, 2, 1)],
+            [None, None, None],
+        ],
         schema_num,
     )
 
@@ -250,7 +254,11 @@ def test_col_not_less_than(spark):
 def test_col_not_greater_than(spark):
     schema_num = "a: int, b: date, c: timestamp"
     test_df = spark.createDataFrame(
-        [[1, "2025-01-01", "2025-01-01 00:00:00"], [2, "2025-02-01", "2025-02-01 00:00:00"], [None, None, None]],
+        [
+            [1, datetime(2025, 1, 1).date(), datetime(2025, 1, 1)],
+            [2, datetime(2025, 2, 1).date(), datetime(2025, 2, 1)],
+            [None, None, None],
+        ],
         schema_num,
     )
 
@@ -279,11 +287,11 @@ def test_col_is_in_range(spark):
     schema_num = "a: int, b: date, c: timestamp"
     test_df = spark.createDataFrame(
         [
-            [0, "2024-12-01", "2024-12-01 00:00:00"],
-            [1, "2025-01-01", "2025-01-01 00:00:00"],
-            [2, "2025-02-01", "2025-02-01 00:00:00"],
-            [3, "2025-03-01", "2025-03-01 00:00:00"],
-            [4, "2025-04-01", "2025-04-01 00:00:00"],
+            [0, datetime(2024, 12, 1).date(), datetime(2024, 12, 1)],
+            [1, datetime(2025, 1, 1).date(), datetime(2025, 1, 1)],
+            [2, datetime(2025, 2, 1).date(), datetime(2025, 2, 1)],
+            [3, datetime(2025, 3, 1).date(), datetime(2025, 3, 1)],
+            [4, datetime(2025, 4, 1).date(), datetime(2025, 4, 1)],
             [None, None, None],
         ],
         schema_num,
@@ -325,9 +333,9 @@ def test_col_is_not_in_range(spark):
     schema_num = "a: int, b: date, c: timestamp"
     test_df = spark.createDataFrame(
         [
-            [1, "2025-01-01", "2025-01-01 00:00:00"],
-            [2, "2025-02-01", "2025-02-01 00:00:00"],
-            [3, "2025-03-01", "2025-03-01 00:00:00"],
+            [1, datetime(2025, 1, 1).date(), datetime(2025, 1, 1)],
+            [2, datetime(2025, 2, 1).date(), datetime(2025, 2, 1)],
+            [3, datetime(2025, 3, 1).date(), datetime(2025, 3, 1)],
             [None, None, None],
         ],
         schema_num,

--- a/tests/integration/test_functions.py
+++ b/tests/integration/test_functions.py
@@ -12,6 +12,7 @@ from databricks.labs.dqx.col_functions import (
     not_in_future,
     not_in_near_future,
     not_less_than,
+    not_greater_than,
     regex_match,
     sql_expression,
     value_is_in_list,
@@ -263,7 +264,9 @@ def test_col_not_greater_than(spark):
     )
 
     actual = test_df.select(
-        not_less_than("a", 1), not_less_than("b", datetime(2025, 1, 1).date()), not_less_than("c", datetime(2025, 1, 1))
+        not_greater_than("a", 1),
+        not_greater_than("b", datetime(2025, 1, 1).date()),
+        not_greater_than("c", datetime(2025, 1, 1)),
     )
 
     checked_schema = "a_greater_than_limit: string", "b_greater_than_limit: string", "c_greater_than_limit: string"
@@ -310,8 +313,8 @@ def test_col_is_in_range(spark):
         [
             [
                 "Value 0 not in range: [ 1 , 3 ]",
-                "Value 2025-01-01 not in range: [ 2025-01-01 , 2025-03-01 ]",
-                "value 2025-01-01 00:00:00 not in range: [ 2025-01-01 00:00:00 , 2025-03-01 00:00:00 ]",
+                "Value 2024-12-01 not in range: [ 2025-01-01 , 2025-03-01 ]",
+                "value 2024-12-01 00:00:00 not in range: [ 2025-01-01 00:00:00 , 2025-03-01 00:00:00 ]",
             ],
             [None, None, None],
             [None, None, None],


### PR DESCRIPTION
## Changes
Added support for both `datetime.date` and `datetime.datetime` arguments to the following column functions:
- `not_less_than`
- `not_greater_than`
- `is_in_range`
- `is_not_in_range`

I used type parameter lists for the `limit` parameter argument of each function. I created the limit as a `pyspark.sql.Column` using `lit(...)` which handles both `datetime.date` and `datetime.datetime` arguments.

### Linked issues
Resolves #136 

### Tests
Integration tests for each column function have been updated to check the condition for `int`, `datetime.date`, and `datetime.datetime` arguments against `IntegerType`, `DateType`, and `TimestampType` columns, respectively.

- [x] manually tested
- [ ] added unit tests
- [x] added integration tests
