### PR TITLE
Disable int tests on forks

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -39,11 +39,6 @@ jobs:
       - name: Install hatch
         run: pip install hatch==1.9.4
 
-      - name: Fetch relevant branches
-        run: |
-          git fetch origin $GITHUB_BASE_REF:$GITHUB_BASE_REF
-          git fetch origin $GITHUB_HEAD_REF:$GITHUB_HEAD_REF
-
       - name: Run integration tests
         uses: databrickslabs/sandbox/acceptance@acceptance/v0.4.2
         with:
@@ -75,11 +70,6 @@ jobs:
 
       - name: Install hatch
         run: pip install hatch==1.9.4
-
-      - name: Fetch relevant branches
-        run: |
-          git fetch origin $GITHUB_BASE_REF:$GITHUB_BASE_REF
-          git fetch origin $GITHUB_HEAD_REF:$GITHUB_HEAD_REF
 
       - name: Run integration tests on serverless cluster
         uses: databrickslabs/sandbox/acceptance@acceptance/v0.4.2

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -20,7 +20,10 @@ concurrency:
 
 jobs:
   integration:
-    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+    # Only run this job for PRs from branches on the main repository and not from forks.
+    # Workflows triggered by PRs from forks don't have access to the tool environment.
+    # PRs from forks to be tested by the reviewer(s) / maintainer(s) before merging.
+    if: github.event_name == 'pull_request' && !github.event.pull_request.draft && !github.event.pull_request.head.repo.fork
     environment: tool
     runs-on: larger
     steps:
@@ -50,7 +53,10 @@ jobs:
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
 
   serverless_integration:
-    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+    # Only run this job for PRs from branches on the main repository and not from forks.
+    # Workflows triggered by PRs from forks don't have access to the tool environment.
+    # PRs from forks to be tested by the reviewer(s) / maintainer(s) before merging.
+    if: github.event_name == 'pull_request' && !github.event.pull_request.draft && !github.event.pull_request.head.repo.fork
     environment: tool
     runs-on: larger
     env:


### PR DESCRIPTION
## Changes
Disable int tests on forks as integration tests cannot currently run on forks. 
PRs from forks must be tested by the reviewer before approval.

### Tests

- [x] manually tested
- [ ] added unit tests
- [ ] added integration tests
