### PR TITLE
Support Column as input to column functions

### DIFF
--- a/src/databricks/labs/dqx/col_functions.py
+++ b/src/databricks/labs/dqx/col_functions.py
@@ -23,45 +23,45 @@ def make_condition(condition: Column, message: Column | str, alias: str) -> Colu
     return (F.when(condition, msg_col).otherwise(F.lit(None).cast("string"))).alias(_cleanup_alias_name(alias))
 
 
-def is_not_null_and_not_empty(col_name: str, trim_strings: bool | None = False) -> Column:
+def is_not_null_and_not_empty(col_name: str | Column, trim_strings: bool | None = False) -> Column:
     """Checks whether the values in the input column are not null and not empty.
 
-    :param col_name: column name to check
+    :param col_name: column to check; can be a column name as a string or column expression
     :param trim_strings: boolean flag to trim spaces from strings
     :return: Column object for condition
     """
-    column = F.col(col_name)
+    column_alias, column_expr = _get_column_expr(col_name)
     if trim_strings:
-        column = F.trim(column).alias(col_name)
-    condition = column.isNull() | (column.cast("string").isNull() | (column.cast("string") == F.lit("")))
-    return make_condition(condition, f"Column {col_name} is null or empty", f"{col_name}_is_null_or_empty")
+        column_expr = F.trim(column_expr).alias(col_name)
+    condition = column_expr.isNull() | (column_expr.cast("string").isNull() | (column_expr.cast("string") == F.lit("")))
+    return make_condition(condition, f"Column {column_alias} is null or empty", f"{column_alias}_is_null_or_empty")
 
 
-def is_not_empty(col_name: str) -> Column:
+def is_not_empty(col_name: str | Column) -> Column:
     """Checks whether the values in the input column are not empty (but may be null).
 
-    :param col_name: column name to check
+    :param col_name: column name to check; can be a column name as a string or column expression
     :return: Column object for condition
     """
-    column = F.col(col_name)
-    condition = column.cast("string") == F.lit("")
-    return make_condition(condition, f"Column {col_name} is empty", f"{col_name}_is_empty")
+    column_alias, column_expr = _get_column_expr(col_name)
+    condition = column_expr.cast("string") == F.lit("")
+    return make_condition(condition, f"Column {column_alias} is empty", f"{column_alias}_is_empty")
 
 
-def is_not_null(col_name: str) -> Column:
+def is_not_null(col_name: str | Column) -> Column:
     """Checks whether the values in the input column are not null.
 
-    :param col_name: column name to check
+    :param col_name: column name to check; can be a column name as a string or column expression
     :return: Column object for condition
     """
-    column = F.col(col_name)
-    return make_condition(column.isNull(), f"Column {col_name} is null", f"{col_name}_is_null")
+    column_alias, column_expr = _get_column_expr(col_name)
+    return make_condition(column_expr.isNull(), f"Column {column_alias} is null", f"{column_alias}_is_null")
 
 
-def is_not_null_and_is_in_list(col_name: str, allowed: list) -> Column:
+def is_not_null_and_is_in_list(col_name: str | Column, allowed: list) -> Column:
     """Checks whether the values in the input column are not null and present in the list of allowed values.
 
-    :param col_name: column name to check
+    :param col_name: column name to check; can be a column name as a string or column expression
     :param allowed: list of allowed values (actual values or Column objects)
     :return: Column object for condition
     """
@@ -69,27 +69,27 @@ def is_not_null_and_is_in_list(col_name: str, allowed: list) -> Column:
         raise ValueError("allowed list is not provided.")
 
     allowed_cols = [item if isinstance(item, Column) else F.lit(item) for item in allowed]
-    column = F.col(col_name)
-    condition = column.isNull() | ~column.isin(*allowed_cols)
+    column_alias, column_expr = _get_column_expr(col_name)
+    condition = column_expr.isNull() | ~column_expr.isin(*allowed_cols)
     return make_condition(
         condition,
         F.concat_ws(
             "",
             F.lit("Value "),
-            F.when(column.isNull(), F.lit("null")).otherwise(column.cast("string")),
+            F.when(column_expr.isNull(), F.lit("null")).otherwise(column_expr.cast("string")),
             F.lit(" is null or not in the allowed list: ["),
             F.concat_ws(", ", *allowed_cols),
             F.lit("]"),
         ),
-        f"{col_name}_is_null_or_is_not_in_the_list",
+        f"{column_alias}_is_null_or_is_not_in_the_list",
     )
 
 
-def is_in_list(col_name: str, allowed: list) -> Column:
+def is_in_list(col_name: str | Column, allowed: list) -> Column:
     """Checks whether the values in the input column are present in the list of allowed values
     (null values are allowed).
 
-    :param col_name: column name to check
+    :param col_name: column name to check; can be a column name as a string or column expression
     :param allowed: list of allowed values (actual values or Column objects)
     :return: Column object for condition
     """
@@ -97,19 +97,19 @@ def is_in_list(col_name: str, allowed: list) -> Column:
         raise ValueError("allowed list is not provided.")
 
     allowed_cols = [item if isinstance(item, Column) else F.lit(item) for item in allowed]
-    column = F.col(col_name)
-    condition = ~column.isin(*allowed_cols)
+    column_alias, column_expr = _get_column_expr(col_name)
+    condition = ~column_expr.isin(*allowed_cols)
     return make_condition(
         condition,
         F.concat_ws(
             "",
             F.lit("Value "),
-            F.when(column.isNull(), F.lit("null")).otherwise(column),
+            F.when(column_expr.isNull(), F.lit("null")).otherwise(column_expr),
             F.lit(" is not in the allowed list: ["),
             F.concat_ws(", ", *allowed_cols),
             F.lit("]"),
         ),
-        f"{col_name}_is_not_in_the_list",
+        f"{column_alias}_is_not_in_the_list",
     )
 
 
@@ -140,36 +140,38 @@ def sql_expression(expression: str, msg: str | None = None, name: str | None = N
     return make_condition(expr_col, F.concat_ws("", F.lit(f"Value matches expression: {expression_msg}")), name)
 
 
-def is_older_than_col2_for_n_days(col_name1: str, col_name2: str, days: int = 0) -> Column:
+def is_older_than_col2_for_n_days(col_name1: str | Column, col_name2: str | Column, days: int = 0) -> Column:
     """Checks whether the values in one input column are at least N days older than the values in another column.
 
-    :param col_name1: first column
-    :param col_name2: second column
+    :param col_name1: first column; can be a column name as a string or column expression
+    :param col_name2: second column; can be a column name as a string or column expression
     :param days: number of days
     :return: new Column
     """
-    col1_date = F.to_date(F.col(col_name1))
-    col2_date = F.to_date(F.col(col_name2))
+    col1_alias, col1_expr = _get_column_expr(col_name1)
+    col2_alias, col2_expr = _get_column_expr(col_name2)
+    col1_date = F.to_date(col1_expr)
+    col2_date = F.to_date(col2_expr)
     condition = col1_date < F.date_sub(col2_date, days)
 
     return make_condition(
         condition,
         F.concat_ws(
             "",
-            F.lit(f"Value of {col_name1}: '"),
+            F.lit(f"Value of {col1_alias}: '"),
             col1_date,
-            F.lit(f"' less than value of {col_name2}: '"),
+            F.lit(f"' less than value of {col2_alias}: '"),
             col2_date,
             F.lit(f"' for more than {days} days"),
         ),
-        f"is_col_{col_name1}_older_than_{col_name2}_for_n_days",
+        f"is_col_{col1_alias}_older_than_{col2_alias}_for_n_days",
     )
 
 
-def is_older_than_n_days(col_name: str, days: int, curr_date: Column | None = None) -> Column:
+def is_older_than_n_days(col_name: str | Column, days: int, curr_date: Column | None = None) -> Column:
     """Checks whether the values in the input column are at least N days older than the current date.
 
-    :param col_name: name of the column to check
+    :param col_name: name of the column to check; can be a column name as a string or column expression
     :param days: number of days
     :param curr_date: (optional) set current date
     :return: new Column
@@ -177,28 +179,29 @@ def is_older_than_n_days(col_name: str, days: int, curr_date: Column | None = No
     if curr_date is None:
         curr_date = F.current_date()
 
-    col_date = F.to_date(F.col(col_name))
+    column_alias, column_expr = _get_column_expr(col_name)
+    col_date = F.to_date(column_expr)
     condition = col_date < F.date_sub(curr_date, days)
 
     return make_condition(
         condition,
         F.concat_ws(
             "",
-            F.lit(f"Value of {col_name}: '"),
+            F.lit(f"Value of {column_alias}: '"),
             col_date,
             F.lit("' less than current date: '"),
             curr_date,
             F.lit(f"' for more than {days} days"),
         ),
-        f"is_col_{col_name}_older_than_n_days",
+        f"is_col_{column_alias}_older_than_n_days",
     )
 
 
-def is_not_in_future(col_name: str, offset: int = 0, curr_timestamp: Column | None = None) -> Column:
+def is_not_in_future(col_name: str | Column, offset: int = 0, curr_timestamp: Column | None = None) -> Column:
     """Checks whether the values in the input column contain a timestamp that is not in the future,
     where 'future' is defined as current_timestamp + offset (in seconds).
 
-    :param col_name: column name
+    :param col_name: column name; can be a column name as a string or column expression
     :param offset: offset (in seconds) to add to the current timestamp at time of execution
     :param curr_timestamp: (optional) set current timestamp
     :return: new Column
@@ -207,23 +210,24 @@ def is_not_in_future(col_name: str, offset: int = 0, curr_timestamp: Column | No
         curr_timestamp = F.current_timestamp()
 
     timestamp_offset = F.from_unixtime(F.unix_timestamp(curr_timestamp) + offset)
-    condition = F.col(col_name) > timestamp_offset
+    column_alias, column_expr = _get_column_expr(col_name)
+    condition = column_expr > timestamp_offset
 
     return make_condition(
         condition,
         F.concat_ws(
-            "", F.lit("Value '"), F.col(col_name), F.lit("' is greater than time '"), timestamp_offset, F.lit("'")
+            "", F.lit("Value '"), column_expr, F.lit("' is greater than time '"), timestamp_offset, F.lit("'")
         ),
-        f"{col_name}_in_future",
+        f"{column_alias}_in_future",
     )
 
 
-def is_not_in_near_future(col_name: str, offset: int = 0, curr_timestamp: Column | None = None) -> Column:
+def is_not_in_near_future(col_name: str | Column, offset: int = 0, curr_timestamp: Column | None = None) -> Column:
     """Checks whether the values in the input column contain a timestamp that is not in the near future,
     where 'near future' is defined as greater than the current timestamp
     but less than the current_timestamp + offset (in seconds).
 
-    :param col_name: column name
+    :param col_name: column name; can be a column name as a string or column expression
     :param offset: offset (in seconds) to add to the current timestamp at time of execution
     :param curr_timestamp: (optional) set current timestamp
     :return: new Column
@@ -232,222 +236,237 @@ def is_not_in_near_future(col_name: str, offset: int = 0, curr_timestamp: Column
         curr_timestamp = F.current_timestamp()
 
     near_future = F.from_unixtime(F.unix_timestamp(curr_timestamp) + offset)
-    condition = (F.col(col_name) > curr_timestamp) & (F.col(col_name) < near_future)
+    column_alias, column_expr = _get_column_expr(col_name)
+    condition = (column_expr > curr_timestamp) & (column_expr < near_future)
 
     return make_condition(
         condition,
         F.concat_ws(
             "",
             F.lit("Value '"),
-            F.col(col_name),
+            column_expr,
             F.lit("' is greater than '"),
             curr_timestamp,
             F.lit(" and smaller than '"),
             near_future,
             F.lit("'"),
         ),
-        f"{col_name}_in_near_future",
+        f"{column_alias}_in_near_future",
     )
 
 
 def is_not_less_than(
-    col_name: str, limit: int | datetime.date | datetime.datetime | str | Column | None = None
+    col_name: str | Column, limit: int | datetime.date | datetime.datetime | str | Column | None = None
 ) -> Column:
     """Checks whether the values in the input column are not less than the provided limit.
 
-    :param col_name: column name
+    :param col_name: column name; can be a column name as a string or column expression
     :param limit: limit to use in the condition as number, date, timestamp, column name or expression
     :return: new Column
     """
-    limit_expr = _get_column_expr_limit(limit)
-    condition = F.col(col_name) < limit_expr
+    limit_expr = _get_limit_expr(limit)
+    column_alias, column_expr = _get_column_expr(col_name)
+    condition = column_expr < limit_expr
 
     return make_condition(
         condition,
-        F.concat_ws(" ", F.lit("Value"), F.col(col_name), F.lit("is less than limit:"), limit_expr.cast("string")),
-        f"{col_name}_less_than_limit",
+        F.concat_ws(" ", F.lit("Value"), column_expr, F.lit("is less than limit:"), limit_expr.cast("string")),
+        f"{column_alias}_less_than_limit",
     )
 
 
 def is_not_greater_than(
-    col_name: str, limit: int | datetime.date | datetime.datetime | str | Column | None = None
+    col_name: str | Column, limit: int | datetime.date | datetime.datetime | str | Column | None = None
 ) -> Column:
     """Checks whether the values in the input column are not greater than the provided limit.
 
-    :param col_name: column name
+    :param col_name: column name; can be a column name as a string or column expression
     :param limit: limit to use in the condition as number, date, timestamp, column name or expression
     :return: new Column
     """
-    limit_expr = _get_column_expr_limit(limit)
-    condition = F.col(col_name) > limit_expr
+    limit_expr = _get_limit_expr(limit)
+    column_alias, column_expr = _get_column_expr(col_name)
+    condition = column_expr > limit_expr
 
     return make_condition(
         condition,
-        F.concat_ws(" ", F.lit("Value"), F.col(col_name), F.lit("is greater than limit:"), limit_expr.cast("string")),
-        f"{col_name}_greater_than_limit",
+        F.concat_ws(" ", F.lit("Value"), column_expr, F.lit("is greater than limit:"), limit_expr.cast("string")),
+        f"{column_alias}_greater_than_limit",
     )
 
 
 def is_in_range(
-    col_name: str,
+    col_name: str | Column,
     min_limit: int | datetime.date | datetime.datetime | str | Column | None = None,
     max_limit: int | datetime.date | datetime.datetime | str | Column | None = None,
 ) -> Column:
     """Checks whether the values in the input column are in the provided limits (inclusive of both boundaries).
 
-    :param col_name: column name
+    :param col_name: column name; can be a column name as a string or column expression
     :param min_limit: min limit to use in the condition as number, date, timestamp, column name or expression
     :param max_limit: max limit to use in the condition as number, date, timestamp, column name or expression
     :return: new Column
     """
-    min_limit_expr = _get_column_expr_limit(min_limit)
-    max_limit_expr = _get_column_expr_limit(max_limit)
+    min_limit_expr = _get_limit_expr(min_limit)
+    max_limit_expr = _get_limit_expr(max_limit)
 
-    condition = (F.col(col_name) < min_limit_expr) | (F.col(col_name) > max_limit_expr)
+    column_alias, column_expr = _get_column_expr(col_name)
+    condition = (column_expr < min_limit_expr) | (column_expr > max_limit_expr)
 
     return make_condition(
         condition,
         F.concat_ws(
             " ",
             F.lit("Value"),
-            F.col(col_name),
+            column_expr,
             F.lit("not in range: ["),
             min_limit_expr.cast("string"),
             F.lit(","),
             max_limit_expr.cast("string"),
             F.lit("]"),
         ),
-        f"{col_name}_not_in_range",
+        f"{column_alias}_not_in_range",
     )
 
 
 def is_not_in_range(
-    col_name: str,
+    col_name: str | Column,
     min_limit: int | datetime.date | datetime.datetime | str | Column | None = None,
     max_limit: int | datetime.date | datetime.datetime | str | Column | None = None,
 ) -> Column:
     """Checks whether the values in the input column are outside the provided limits (inclusive of both boundaries).
 
-    :param col_name: column name
+    :param col_name: column name; can be a column name as a string or column expression
     :param min_limit: min limit to use in the condition as number, date, timestamp, column name or expression
     :param max_limit: min limit to use in the condition as number, date, timestamp, column name or expression
     :return: new Column
     """
-    min_limit_expr = _get_column_expr_limit(min_limit)
-    max_limit_expr = _get_column_expr_limit(max_limit)
+    min_limit_expr = _get_limit_expr(min_limit)
+    max_limit_expr = _get_limit_expr(max_limit)
 
-    condition = (F.col(col_name) >= min_limit_expr) & (F.col(col_name) <= max_limit_expr)
+    column_alias, column_expr = _get_column_expr(col_name)
+    condition = (column_expr >= min_limit_expr) & (column_expr <= max_limit_expr)
 
     return make_condition(
         condition,
         F.concat_ws(
             " ",
             F.lit("Value"),
-            F.col(col_name),
+            column_expr,
             F.lit("in range: ["),
             min_limit_expr.cast("string"),
             F.lit(","),
             max_limit_expr.cast("string"),
             F.lit("]"),
         ),
-        f"{col_name}_in_range",
+        f"{column_alias}_in_range",
     )
 
 
-def regex_match(col_name: str, regex: str, negate: bool = False) -> Column:
+def regex_match(col_name: str | Column, regex: str, negate: bool = False) -> Column:
     """Checks whether the values in the input column matches a given regex.
 
-    :param col_name: column name to check
+    :param col_name: column name to check; can be a column name as a string or column expression
     :param regex: regex to check
     :param negate: if the condition should be negated (true) or not
     :return: Column object for condition
     """
+    column_alias, column_expr = _get_column_expr(col_name)
     if negate:
-        condition = F.col(col_name).rlike(regex)
+        condition = column_expr.rlike(regex)
 
-        return make_condition(condition, f"Column {col_name} is matching regex", f"{col_name}_matching_regex")
+        return make_condition(condition, f"Column {column_alias} is matching regex", f"{column_alias}_matching_regex")
 
-    condition = ~F.col(col_name).rlike(regex)
+    condition = ~column_expr.rlike(regex)
 
-    return make_condition(condition, f"Column {col_name} is not matching regex", f"{col_name}_not_matching_regex")
+    return make_condition(condition, f"Column {column_alias} is not matching regex", f"{column_alias}_not_matching_regex")
 
 
-def is_not_null_and_not_empty_array(col_name: str) -> Column:
+def is_not_null_and_not_empty_array(col_name: str | Column) -> Column:
     """Checks whether the values in the array input column are not null and not empty.
 
-    :param col_name: column name to check
+    :param col_name: column name to check; can be a column name as a string or column expression
     :return: Column object for condition
     """
-    column = F.col(col_name)
-    condition = column.isNull() | (F.size(column) == 0)
-    return make_condition(condition, f"Column {col_name} is null or empty array", f"{col_name}_is_null_or_empty_array")
+    column_alias, column_expr = _get_column_expr(col_name)
+    condition = column_expr.isNull() | (F.size(column_expr) == 0)
+    return make_condition(
+        condition,
+        f"Column {column_alias} is null or empty array", f"{column_alias}_is_null_or_empty_array"
+    )
 
 
-def is_valid_date(col_name: str, date_format: str | None = None) -> Column:
+def is_valid_date(col_name: str | Column, date_format: str | None = None) -> Column:
     """Checks whether the values in the input column have valid date formats.
 
-    :param col_name: column name to check
+    :param col_name: column name to check; can be a column name as a string or column expression
     :param date_format: date format (e.g. 'yyyy-mm-dd')
     :return: Column object for condition
     """
-    column = F.col(col_name)
-    date_col = F.try_to_timestamp(column) if date_format is None else F.try_to_timestamp(column, F.lit(date_format))
-    condition = F.when(column.isNull(), F.lit(None)).otherwise(date_col.isNull())
+    column_alias, column_expr = _get_column_expr(col_name)
+    date_col = (
+        F.try_to_timestamp(column_expr)
+        if date_format is None
+        else F.try_to_timestamp(column_expr, F.lit(date_format))
+    )
+    condition = F.when(column_expr.isNull(), F.lit(None)).otherwise(date_col.isNull())
     condition_str = "' is not a valid date"
     if date_format is not None:
         condition_str += f" with format '{date_format}'"
     return make_condition(
         condition,
-        F.concat_ws("", F.lit("Value '"), column, F.lit(condition_str)),
-        f"{col_name}_is_not_valid_date",
+        F.concat_ws("", F.lit("Value '"), column_expr, F.lit(condition_str)),
+        f"{column_alias}_is_not_valid_date",
     )
 
 
-def is_valid_timestamp(col_name: str, timestamp_format: str | None = None) -> Column:
+def is_valid_timestamp(col_name: str | Column, timestamp_format: str | None = None) -> Column:
     """Checks whether the values in the input column have valid timestamp formats.
 
-    :param col_name: column name to check
+    :param col_name: column name to check; can be a column name as a string or column expression
     :param timestamp_format: timestamp format (e.g. 'yyyy-mm-dd HH:mm:ss')
     :return: Column object for condition
     """
-    column = F.col(col_name)
+    column_alias, column_expr = _get_column_expr(col_name)
     ts_col = (
-        F.try_to_timestamp(column) if timestamp_format is None else F.try_to_timestamp(column, F.lit(timestamp_format))
+        F.try_to_timestamp(column_expr)
+        if timestamp_format is None
+        else F.try_to_timestamp(column_expr, F.lit(timestamp_format))
     )
-    condition = F.when(column.isNull(), F.lit(None)).otherwise(ts_col.isNull())
+    condition = F.when(column_expr.isNull(), F.lit(None)).otherwise(ts_col.isNull())
     condition_str = "' is not a valid timestamp"
     if timestamp_format is not None:
         condition_str += f" with format '{timestamp_format}'"
     return make_condition(
         condition,
-        F.concat_ws("", F.lit("Value '"), column, F.lit(condition_str)),
-        f"{col_name}_is_not_valid_timestamp",
+        F.concat_ws("", F.lit("Value '"), column_expr, F.lit(condition_str)),
+        f"{column_alias}_is_not_valid_timestamp",
     )
 
 
-def is_unique(col_name: str, window_spec: str | Column | None = None) -> Column:
+def is_unique(col_name: str | Column, window_spec: str | Column | None = None) -> Column:
     """Checks whether the values in the input column are unique
     and reports an issue for each row that contains a duplicate value.
     Null values are not considered duplicates, following the ANSI SQL standard.
     It should be used carefully in the streaming context,
     as uniqueness check will only be performed on individual micro-batches.
 
-    :param col_name: column name to check
+    :param col_name: column name to check; can be a column name as a string or column expression
     :param window_spec: window specification for the partition by clause. Default value for NULL in the time column
     of the window spec must be provided using coalesce() to prevent rows exclusion!
     e.g. "window(coalesce(b, '1970-01-01'), '2 hours')"
     :return: Column object for condition
     """
-    column = F.col(col_name)
+    column_alias, column_expr = _get_column_expr(col_name)
     if window_spec is None:
-        partition_by_spec = Window.partitionBy(column)
+        partition_by_spec = Window.partitionBy(column_expr)
     else:
         if isinstance(window_spec, str):
             window_spec = F.expr(window_spec)
         partition_by_spec = Window.partitionBy(window_spec)
 
-    condition = F.when(column.isNotNull(), F.count(column).over(partition_by_spec) == 1)
-    return make_condition(~condition, f"Column {col_name} has duplicate values", f"{col_name}_is_not_unique")
+    condition = F.when(column_expr.isNotNull(), F.count(column_expr).over(partition_by_spec) == 1)
+    return make_condition(~condition, f"Column {column_alias} has duplicate values", f"{column_alias}_is_not_unique")
 
 
 def _cleanup_alias_name(col_name: str) -> str:
@@ -455,7 +474,7 @@ def _cleanup_alias_name(col_name: str) -> str:
     return col_name.replace(".", "_")
 
 
-def _get_column_expr_limit(
+def _get_limit_expr(
     limit: int | datetime.date | datetime.datetime | str | Column | None = None,
 ) -> Column:
     """Helper function to generate a column expression limit based on the provided limit value.
@@ -472,3 +491,17 @@ def _get_column_expr_limit(
     if isinstance(limit, Column):
         return limit
     return F.lit(limit)
+
+
+def _get_column_expr(column: str | Column) -> (str, Column):
+    if isinstance(column, str):
+        return column, F.col(column)
+    return _get_column_expr_alias(column), column
+
+
+def _get_column_expr_alias(column: Column) -> str:
+    match = re.search(r"Column<'(.*)'>", str(column))
+    if match is None:
+        raise ValueError("Invalid column expression string")
+    raw_alias = match.group(1)
+    return re.sub(normalize_regex, "_", raw_alias.lower())


### PR DESCRIPTION
## Changes
Allow check functions to receive a `pyspark.sql.Column` in addition to the column name as a `str`.

This allows users to run column check functions on complex types (e.g. `MapType`).

### Linked issues
Resolves https://github.com/databrickslabs/dqx/issues/208

### Tests
I updated several integration tests to test column expression inputs.

- [ ] manually tested
- [ ] added unit tests
- [x] added integration tests
