### PR TITLE
Trim autogenerated check name to 255 chars

### DIFF
--- a/src/databricks/labs/dqx/utils.py
+++ b/src/databricks/labs/dqx/utils.py
@@ -14,11 +14,13 @@ def get_column_name(col: Column) -> str:
     It is necessary to parse this out from the string representation.
 
     This works on columns with one or more aliases as well as not aliased columns.
+    The resulting name is truncated to 255 characters to avoid potential issues with the column name length.
 
     :param col: Column
     :return: Col name alias as str
     """
-    return str(col).removeprefix("Column<'").removesuffix("'>").split(" AS ")[-1]
+    max_chars = 255
+    return str(col).removeprefix("Column<'").removesuffix("'>").split(" AS ")[-1][:max_chars]
 
 
 def read_input_data(spark: SparkSession, input_location: str | None, input_format: str | None):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -27,6 +27,14 @@ def test_get_col_name_longer():
     assert actual == "local"
 
 
+def test_get_col_name_and_truncate():
+    long_col_name = "a" * 300
+    col = F.col(long_col_name)
+    actual = get_column_name(col)
+    max_chars = 255
+    assert len(actual) == max_chars
+
+
 def test_read_input_data_no_input_location(spark_local):
     with pytest.raises(ValueError, match="Input location not configured"):
         read_input_data(spark_local, None, None)


### PR DESCRIPTION
## Changes

* Trim autogenerated check name to 255 chars to avoid potential issues when using the results

### Linked issues

Resolves #216 

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [x] added unit tests
- [ ] added integration tests
