### PR TITLE
Load and save checks from a Delta table

### DIFF
--- a/src/databricks/labs/dqx/config.py
+++ b/src/databricks/labs/dqx/config.py
@@ -17,6 +17,7 @@ class RunConfig:
     output_table: str | None = None  # output data table
     quarantine_table: str | None = None  # quarantined data table
     checks_file: str | None = "checks.yml"  # file containing quality rules / checks
+    checks_table: str | None = None  # table containing quality rules / checks
     profile_summary_stats_file: str | None = "profile_summary_stats.yml"  # file containing profile summary statistics
     override_clusters: dict[str, str] | None = None  # cluster configuration for jobs
     spark_conf: dict[str, str] | None = None  # extra spark configs

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -80,14 +80,10 @@ class MockRuntimeContext(CommonUtils, RuntimeContext):
 class MockInstallationContext(MockRuntimeContext):
     __test__ = False
 
-    def __init__(
-        self,
-        env_or_skip_fixture,
-        ws,
-        check_file,
-    ):
+    def __init__(self, env_or_skip_fixture, ws, check_file, check_table):
         super().__init__(env_or_skip_fixture, ws)
         self.check_file = check_file
+        self.check_table = check_table
 
     @cached_property
     def installation(self):
@@ -113,7 +109,9 @@ class MockInstallationContext(MockRuntimeContext):
         workspace_config = self.workspace_installer.configure()
 
         for i, run_config in enumerate(workspace_config.run_configs):
-            workspace_config.run_configs[i] = replace(run_config, checks_file=self.check_file)
+            workspace_config.run_configs[i] = replace(
+                run_config, checks_file=self.check_file, checks_table=self.check_table
+            )
 
         workspace_config = self.config_transform(workspace_config)
         self.installation.save(workspace_config)
@@ -171,15 +169,9 @@ class MockInstallationContext(MockRuntimeContext):
 
 @pytest.fixture
 def installation_ctx(
-    ws,
-    env_or_skip,
-    check_file="checks.yml",
+    ws, env_or_skip, check_file="checks.yml", check_table="labs.dqx.checks_table"
 ) -> Generator[MockInstallationContext, None, None]:
-    ctx = MockInstallationContext(
-        env_or_skip,
-        ws,
-        check_file,
-    )
+    ctx = MockInstallationContext(env_or_skip, ws, check_file, check_table)
     yield ctx.replace(workspace_client=ws)
     ctx.workspace_installation.uninstall()
 

--- a/tests/integration/test_load_checks_from_table.py
+++ b/tests/integration/test_load_checks_from_table.py
@@ -1,0 +1,32 @@
+import pytest
+from databricks.labs.dqx.engine import DQEngine
+from databricks.sdk.errors import NotFound
+
+
+TEST_CHECKS = [
+    {"criticality": "error", "check": {"function": "is_not_null", "arguments": {"col_names": ["col1", "col2"]}}},
+    {"criticality": "warning", "check": {"function": "is_not_null_or_empty", "arguments": {"col_names": ["col_1"]}}},
+]
+
+
+def test_load_checks_when_checks_table_does_not_exist_in_workspace(ws, installation_ctx):
+    checks_table = installation_ctx.check_table
+    with pytest.raises(NotFound, match=f"Table {checks_table} does not exist in the workspace"):
+        engine = DQEngine(ws)
+        engine.load_checks_from_table(checks_table)
+
+
+def test_load_checks_from_table(ws, installation_ctx):
+    checks_table = installation_ctx.check_table
+    engine = DQEngine(ws)
+    engine.save_checks_in_table(TEST_CHECKS, checks_table)
+    checks = engine.load_checks_from_table(checks_table)
+    assert checks == TEST_CHECKS, "Checks were not loaded correctly"
+
+
+def test_load_checks_from_table_with_query(ws, installation_ctx):
+    checks_table = installation_ctx.check_table
+    engine = DQEngine(ws)
+    engine.save_checks_in_table(TEST_CHECKS, checks_table)
+    checks = engine.load_checks_from_table(checks_table, "criticality <> 'warning'")
+    assert checks == [c for c in TEST_CHECKS if c["criticality"] != "warning"], "Checks were not loaded correctly"

--- a/tests/integration/test_save_checks_to_table.py
+++ b/tests/integration/test_save_checks_to_table.py
@@ -1,0 +1,18 @@
+from databricks.labs.dqx.engine import DQEngine
+
+
+TEST_CHECKS = [
+    {"criticality": "error", "check": {"function": "is_not_null", "arguments": {"col_names": ["col1", "col2"]}}},
+    {"criticality": "warning", "check": {"function": "is_not_null_or_empty", "arguments": {"col_names": ["col_1"]}}},
+]
+
+
+def test_save_checks_in_table(ws, installation_ctx):
+    installation_ctx.installation.save(installation_ctx.config)
+
+    dq_engine = DQEngine(ws)
+    checks_table = installation_ctx.check_table
+
+    dq_engine.save_checks_in_table(TEST_CHECKS, checks_table)
+    checks = dq_engine.load_checks_from_table(checks_table)
+    assert TEST_CHECKS == checks, "Checks were not saved correctly"


### PR DESCRIPTION
## Changes
Added the following methods to the `DQEngine` class to save and load checks to a Delta table in a Databricks workspace:
- `save_checks_in_table`
- `load_checks_from_table`

### Linked issues
Resolves #299 

### Tests
Added integration tests.

- [x] manually tested
- [ ] added unit tests
- [x] added integration tests
