### PR TITLE
Fix spark remote version detection in CI

### DIFF
--- a/.github/scripts/setup_spark_remote.sh
+++ b/.github/scripts/setup_spark_remote.sh
@@ -6,11 +6,12 @@ echo "Setting up spark-connect"
 mkdir -p "$HOME"/spark
 cd "$HOME"/spark || exit 1
 
-version=$(wget -O - https://dlcdn.apache.org/spark/ | grep 'href="spark' | grep -v 'preview' | sed 's:</a>:\n:g' | sed -n 's/.*>//p' | tr -d spark- | tr -d / | sort -r --version-sort | head -1)
+version=$(wget -O - https://dlcdn.apache.org/spark/ | grep 'href="spark-[0-9.]*/"' | sed 's:</a>:\n:g' | sed -n 's/.*>//p' | tr -d spark/- | sort -r --version-sort | head -1)
 if [ -z "$version" ]; then
   echo "Failed to extract Spark version"
    exit 1
 fi
+echo "Loading spark version $version"
 
 spark=spark-${version}-bin-hadoop3
 spark_connect="spark-connect_2.12"


### PR DESCRIPTION
## Changes
Fix spark version detection in CI integration. 
The CI fails because the spark download page has new entries that our version extractor does not properly parse.

### Tests
- [x] manually tested
- [ ] added unit tests
- [ ] added integration tests
