### PR TITLE
Fix spark remote installation

### DIFF
--- a/.github/scripts/setup_spark_remote.sh
+++ b/.github/scripts/setup_spark_remote.sh
@@ -5,8 +5,18 @@ echo "Setting up spark-connect"
 
 mkdir -p "$HOME"/spark
 cd "$HOME"/spark || exit 1
+spark_versions=$(wget -qO - https://dlcdn.apache.org/spark/ | grep 'href="spark-[0-9.]*\/"' | sed 's:</a>:\n:g' | sed -n 's/.*>//p' | tr -d spark/- | sort -rV)
+echo "Available Spark versions:" $spark_versions
 
-version=$(wget -O - https://dlcdn.apache.org/spark/ | grep 'href="spark-[0-9.]*/"' | sed 's:</a>:\n:g' | sed -n 's/.*>//p' | tr -d spark/- | sort -r --version-sort | head -1)
+desired_version="3.5"
+matching_version=$(echo "$spark_versions" | grep "^${desired_version}\." | head -1)
+
+if [ -n "$matching_version" ]; then
+    version=$matching_version
+else
+    version=$(echo "$spark_versions" | head -1)
+fi
+
 if [ -z "$version" ]; then
   echo "Failed to extract Spark version"
    exit 1


### PR DESCRIPTION
## Changes

Updated spark remote installation to use latest spark 3.5 by default to avoid fetching 4.0.0 which is in preview and causes some negative unit tests to execute slower and timeout


### Tests
- [x] manually tested
- [ ] added unit tests
- [ ] added integration tests
