### PR TITLE
Add equality checks for aggregate values

### DIFF
--- a/docs/dqx/docs/guide/quality_checks.mdx
+++ b/docs/dqx/docs/guide/quality_checks.mdx
@@ -108,6 +108,24 @@ Below is an example `yaml` file ('checks.yml') defining several checks:
       group_by:
       - col2
       limit: 1.2
+- criticality: error
+  check:
+    function: is_aggr_equal
+    arguments:
+      column: col1
+      aggr_type: count
+      group_by:
+      - col2
+      limit: 5
+- criticality: error
+  check:
+    function: is_aggr_not_equal
+    arguments:
+      column: col1
+      aggr_type: avg
+      group_by:
+      - col2
+      limit: 10.5
 ```
 Fields:
 - `criticality`: either "error" (data going only into "bad/quarantine" dataframe) or "warn" (data going into both "good" and "bad" dataframes). If not provided, the default is "error".
@@ -372,6 +390,18 @@ Example:
         column="col1",
         check_func_kwargs={"aggr_type": "avg", "group_by": ["col2"], "limit": 1.2},
       ),
+      DQRowRule(  # aggregation check working across group of rows
+        criticality="error",
+        check_func=check_funcs.is_aggr_equal,
+        column="col1",
+        check_func_kwargs={"aggr_type": "count", "group_by": ["col2"], "limit": 5},
+      ),
+      DQRowRule(  # aggregation check working across group of rows
+        criticality="error",
+        check_func=check_funcs.is_aggr_not_equal,
+        column="col1",
+        check_func_kwargs={"aggr_type": "avg", "group_by": ["col2"], "limit": 10.5},
+      ),
     ]
 
     input_df = spark.read.table("catalog1.schema1.table1")
@@ -491,6 +521,24 @@ Example:
           group_by:
           - col2
           limit: 1.2
+    - criticality: error
+      check:
+        function: is_aggr_equal
+        arguments:
+          column: col1
+          aggr_type: count
+          group_by:
+          - col2
+          limit: 5
+    - criticality: error
+      check:
+        function: is_aggr_not_equal
+        arguments:
+          column: col1
+          aggr_type: avg
+          group_by:
+          - col2
+          limit: 10.5
     """)
 
     input_df = spark.read.table("catalog1.schema1.table1")

--- a/docs/dqx/docs/reference/quality_rules.mdx
+++ b/docs/dqx/docs/reference/quality_rules.mdx
@@ -40,6 +40,8 @@ In all cases, the quality check results are always reported for individual rows 
 | is_unique                        | Checks whether the values in the input column are unique and reports an issue for each row that contains a duplicate value. It supports uniqueness check for multiple columns (composite key). Null values are not considered duplicates by default, following the ANSI SQL standard.                                                                  | columns: columns to check (can be a list of column names or column expressions); window_spec: optional window specification as a string or column object, you must handle NULLs correctly using coalesce() to prevent rows exclusion; nulls_distinct: controls how null values are treated, default is True, thus nulls are not duplicates, eg. (NULL, NULL) not equals (NULL, NULL) and (1, NULL) not equals (1, NULL)                                                                | Yes                      |
 | is_aggr_not_greater_than         | Checks whether the aggregated values over group of rows or all rows are not greater than the provided limit.                                                                                                                                                                                                                                           | column: column to check (can be a string column name or a column expression), optional for 'count' aggregation; limit: limit as number, column name or sql expression; aggr_type: aggregation function to use, such as "count" (default), "sum", "avg", "min", and "max"; group_by: optional list of columns or column expressions to group the rows for aggregation (no grouping by default); row_filter: filter from the check definition, auto-injected when applying the check     | Yes                      |
 | is_aggr_not_less_than            | Checks whether the aggregated values over group of rows or all rows are not less than the provided limit.                                                                                                                                                                                                                                              | column: column to check (can be a string column name or a column expression), optional for 'count' aggregation; limit: limit as number, column name or sql expression; aggr_type: aggregation function to use, such as "count" (default), "sum", "avg", "min", and "max"; group_by: optional list of columns or column expressions to group the rows for aggregation (no grouping by default); row_filter: filter from the check definition, auto-injected when applying the check     | Yes                      |
+| is_aggr_equal                    | Checks whether the aggregated values over group of rows or all rows are equal to the provided limit.                                                                                                                                                                                                                                                   | column: column to check (can be a string column name or a column expression), optional for 'count' aggregation; limit: limit as number, column name or sql expression; aggr_type: aggregation function to use, such as "count" (default), "sum", "avg", "min", and "max"; group_by: optional list of columns or column expressions to group the rows for aggregation (no grouping by default); row_filter: filter from the check definition, auto-injected when applying the check     | Yes                      |
+| is_aggr_not_equal                | Checks whether the aggregated values over group of rows or all rows are not equal to the provided limit.                                                                                                                                                                                                                                               | column: column to check (can be a string column name or a column expression), optional for 'count' aggregation; limit: limit as number, column name or sql expression; aggr_type: aggregation function to use, such as "count" (default), "sum", "avg", "min", and "max"; group_by: optional list of columns or column expressions to group the rows for aggregation (no grouping by default); row_filter: filter from the check definition, auto-injected when applying the check     | Yes                      |
 | PII detection                    | Checks whether the values in the input column contain Personally Identifiable Information (PII). This check is not included in DQX built-in rules to avoid introducing 3rd-party dependencies. An example implementation can be found [here](/docs/reference/quality_rules#detecting-personally-identifiable-information-pii-using-a-python-function). |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | No                       |
 </details>
 
@@ -385,6 +387,64 @@ For brevity, the `name` field in the examples is omitted and it will be auto-gen
       group_by:
       - col3
       limit: 1
+
+# is_aggr_equal check with count aggregation over all rows
+- criticality: error
+  check:
+    function: is_aggr_equal
+    arguments:
+      column: '*'
+      aggr_type: count
+      limit: 100
+
+# is_aggr_equal check with aggregation over col2 (skip nulls)
+- criticality: error
+  check:
+    function: is_aggr_equal
+    arguments:
+      column: col2
+      aggr_type: count # other types: sum, avg, min, max
+      limit: 50
+
+# is_aggr_equal check with aggregation over col2 grouped by col3 (skip nulls)
+- criticality: error
+  check:
+    function: is_aggr_equal
+    arguments:
+      column: col2
+      aggr_type: sum # other types: count, avg, min, max
+      group_by:
+      - col3
+      limit: 1000
+
+# is_aggr_not_equal check with count aggregation over all rows
+- criticality: error
+  check:
+    function: is_aggr_not_equal
+    arguments:
+      column: '*'
+      aggr_type: count
+      limit: 100
+
+# is_aggr_not_equal check with aggregation over col2 (skip nulls)
+- criticality: error
+  check:
+    function: is_aggr_not_equal
+    arguments:
+      column: col2
+      aggr_type: count # other types: sum, avg, min, max
+      limit: 50
+
+# is_aggr_not_equal check with aggregation over col2 grouped by col3 (skip nulls)
+- criticality: error
+  check:
+    function: is_aggr_not_equal
+    arguments:
+      column: col2
+      aggr_type: avg # other types: count, sum, min, max
+      group_by:
+      - col3
+      limit: 25.5
 
 # regex_match check
 - criticality: error
@@ -745,6 +805,68 @@ checks = [
         "aggr_type": "count",
         "group_by": ["col3"],
         "limit": 1
+      },
+    ),
+    # is_aggr_equal check with count aggregation over all rows
+    DQRowRule(
+      criticality="error",
+      check_func=check_funcs.is_aggr_equal,
+      check_func_kwargs={
+        "column": "*",
+        "aggr_type": "count",
+        "limit": 100
+      },
+    ),
+    # is_aggr_equal check with aggregation over col2 (skip nulls)
+    DQRowRule(
+      criticality="error",
+      check_func=check_funcs.is_aggr_equal,
+      column="col2",
+      check_func_kwargs={
+        "aggr_type": "count",
+        "limit": 50
+      },
+    ),
+    # is_aggr_equal check with aggregation over col2 grouped by col3 (skip nulls)
+    DQRowRule(
+      criticality="error",
+      check_func=check_funcs.is_aggr_equal,
+      column="col2",
+      check_func_kwargs={
+        "aggr_type": "sum",
+        "group_by": ["col3"],
+        "limit": 1000
+      },
+    ),
+    # is_aggr_not_equal check with count aggregation over all rows
+    DQRowRule(
+      criticality="error",
+      check_func=check_funcs.is_aggr_not_equal,
+      check_func_kwargs={
+        "column": "*",
+        "aggr_type": "count",
+        "limit": 100
+      },
+    ),
+    # is_aggr_not_equal check with aggregation over col2 (skip nulls)
+    DQRowRule(
+      criticality="error",
+      check_func=check_funcs.is_aggr_not_equal,
+      column="col2",
+      check_func_kwargs={
+        "aggr_type": "count",
+        "limit": 50
+      },
+    ),
+    # is_aggr_not_equal check with aggregation over col2 grouped by col3 (skip nulls)
+    DQRowRule(
+      criticality="error",
+      check_func=check_funcs.is_aggr_not_equal,
+      column="col2",
+      check_func_kwargs={
+        "aggr_type": "avg",
+        "group_by": ["col3"],
+        "limit": 25.5
       },
     ),
     # regex_match check

--- a/src/databricks/labs/dqx/check_funcs.py
+++ b/src/databricks/labs/dqx/check_funcs.py
@@ -635,6 +635,70 @@ def is_aggr_not_less_than(
     )
 
 
+@register_rule("single_column")
+def is_aggr_equal(
+    column: str | Column,
+    limit: int | float | str | Column,
+    row_filter: str | None = None,  # auto-injected when applying checks
+    aggr_type: str = "count",
+    group_by: list[str | Column] | None = None,
+) -> Column:
+    """
+    Returns a Column expression indicating whether an aggregation over all or group of rows is not equal to the limit.
+    Nulls are excluded from aggregations. To include rows with nulls for count aggregation, pass "*" for the column.
+
+    :param column: column to apply the aggregation on; can be a list of column names or column expressions
+    :param row_filter: SQL filter expression to apply for aggregation; auto-injected using check filter
+    :param limit: Limit to use in the condition as number, column name or sql expression
+    :param aggr_type: Aggregation type - "count", "sum", "avg", "max", or "min"
+    :param group_by: Optional list of columns or column expressions to group by
+    before counting rows to check row count per group of columns.
+    :return: Column expression (same for every row) indicating if aggregation is not equal to limit
+    """
+    return _is_aggr_compare(
+        column,
+        limit,
+        aggr_type,
+        row_filter,
+        group_by,
+        compare_op=py_operator.ne,
+        compare_op_label="not equal to",
+        compare_op_name="not_equal_to",
+    )
+
+
+@register_rule("single_column")
+def is_aggr_not_equal(
+    column: str | Column,
+    limit: int | float | str | Column,
+    row_filter: str | None = None,  # auto-injected when applying checks
+    aggr_type: str = "count",
+    group_by: list[str | Column] | None = None,
+) -> Column:
+    """
+    Returns a Column expression indicating whether an aggregation over all or group of rows is equal to the limit.
+    Nulls are excluded from aggregations. To include rows with nulls for count aggregation, pass "*" for the column.
+
+    :param column: column to apply the aggregation on; can be a list of column names or column expressions
+    :param row_filter: SQL filter expression to apply for aggregation; auto-injected using check filter
+    :param limit: Limit to use in the condition as number, column name or sql expression
+    :param aggr_type: Aggregation type - "count", "sum", "avg", "max", or "min"
+    :param group_by: Optional list of columns or column expressions to group by
+    before counting rows to check row count per group of columns.
+    :return: Column expression (same for every row) indicating if aggregation is equal to limit
+    """
+    return _is_aggr_compare(
+        column,
+        limit,
+        aggr_type,
+        row_filter,
+        group_by,
+        compare_op=py_operator.eq,
+        compare_op_label="equal to",
+        compare_op_name="equal_to",
+    )
+
+
 def _is_aggr_compare(
     column: str | Column,
     limit: int | float | str | Column,

--- a/tests/integration/test_apply_checks.py
+++ b/tests/integration/test_apply_checks.py
@@ -2995,6 +2995,28 @@ def test_apply_checks_all_checks_using_classes(ws, spark):
             },
             user_metadata={"tag1": "value5"},
         ),
+        DQRowRule(
+            name="a_count_group_by_a_less_than_limit_with_b_not_null",
+            criticality="error",
+            check_func=check_funcs.is_aggr_not_less_than,
+            column="a",
+            filter="b is not null",
+            check_func_kwargs={"group_by": ["a"], "limit": 10, "aggr_type": "count"},
+        ),
+        DQRowRule(
+            criticality="warn",
+            check_func=check_funcs.is_aggr_equal,
+            column="*",  # count all rows
+            check_func_kwargs={"aggr_type": "count", "limit": 3},
+        ),
+        DQRowRule(
+            name="a_count_equal_to_limit_with_filter",
+            criticality="error",
+            check_func=check_funcs.is_aggr_equal,
+            column="a",
+            filter="b is not null",
+            check_func_kwargs={"aggr_type": "count", "limit": 1},
+        ),
     ]
 
     # apply check to multiple columns
@@ -3728,6 +3750,48 @@ def test_apply_aggr_checks(ws, spark):
             filter="b is not null",
             check_func_kwargs={"group_by": ["a"], "limit": 10, "aggr_type": "count"},
         ),
+        DQRowRule(
+            criticality="warn",
+            check_func=check_funcs.is_aggr_equal,
+            column="*",  # count all rows
+            check_func_kwargs={"aggr_type": "count", "limit": 3},
+        ),
+        DQRowRule(
+            name="a_count_equal_to_limit_with_filter",
+            criticality="error",
+            check_func=check_funcs.is_aggr_equal,
+            column="a",
+            filter="b is not null",
+            check_func_kwargs={"aggr_type": "count", "limit": 1},
+        ),
+        DQRowRule(
+            criticality="warn",
+            check_func=check_funcs.is_aggr_not_equal,
+            column="*",  # count all rows
+            check_func_kwargs={"aggr_type": "count", "limit": 3},
+        ),
+        DQRowRule(
+            name="a_count_not_equal_to_limit",
+            criticality="error",
+            check_func=check_funcs.is_aggr_not_equal,
+            column="a",
+            check_func_kwargs={"aggr_type": "count", "limit": 2},
+        ),
+        DQRowRule(
+            name="a_count_not_equal_to_limit_with_filter",
+            criticality="error",
+            check_func=check_funcs.is_aggr_not_equal,
+            column="a",
+            filter="b is not null",
+            check_func_kwargs={"aggr_type": "count", "limit": 1},
+        ),
+        DQRowRule(
+            name="c_avg_not_equal_to_limit",
+            criticality="warn",
+            check_func=check_funcs.is_aggr_not_equal,
+            column="c",
+            check_func_kwargs={"aggr_type": "avg", "limit": 4.0},
+        ),
     ]
 
     all_df = dq_engine.apply_checks(test_df, checks)
@@ -3747,7 +3811,16 @@ def test_apply_aggr_checks(ws, spark):
                         "function": "is_aggr_not_greater_than",
                         "run_time": RUN_TIME,
                         "user_metadata": {},
-                    }
+                    },
+                    {
+                        "name": "a_count_not_equal_to_limit",
+                        "message": "Count 2 in column 'a' is equal to limit: 2",
+                        "columns": ["a"],
+                        "filter": None,
+                        "function": "is_aggr_not_equal",
+                        "run_time": RUN_TIME,
+                        "user_metadata": {},
+                    },
                 ],
                 [
                     {

--- a/tests/resources/all_checks.yaml
+++ b/tests/resources/all_checks.yaml
@@ -425,3 +425,61 @@
     - try_element_at(col7, 'key1') # map col
     - try_element_at(col4, 1) # array col
 
+# is_aggr_equal check with count aggregation over all rows
+- criticality: error
+  check:
+    function: is_aggr_equal
+    arguments:
+      column: '*'
+      aggr_type: count
+      limit: 100
+
+# is_aggr_equal check with aggregation over col2 (skip nulls)
+- criticality: error
+  check:
+    function: is_aggr_equal
+    arguments:
+      column: col2
+      aggr_type: count # other types: sum, avg, min, max
+      limit: 50
+
+# is_aggr_equal check with aggregation over col2 grouped by col3 (skip nulls)
+- criticality: error
+  check:
+    function: is_aggr_equal
+    arguments:
+      column: col2
+      aggr_type: sum # other types: count, avg, min, max
+      group_by:
+      - col3
+      limit: 1000
+
+# is_aggr_not_equal check with count aggregation over all rows
+- criticality: error
+  check:
+    function: is_aggr_not_equal
+    arguments:
+      column: '*'
+      aggr_type: count
+      limit: 100
+
+# is_aggr_not_equal check with aggregation over col2 (skip nulls)
+- criticality: error
+  check:
+    function: is_aggr_not_equal
+    arguments:
+      column: col2
+      aggr_type: count # other types: sum, avg, min, max
+      limit: 50
+
+# is_aggr_not_equal check with aggregation over col2 grouped by col3 (skip nulls)
+- criticality: error
+  check:
+    function: is_aggr_not_equal
+    arguments:
+      column: col2
+      aggr_type: avg # other types: count, sum, min, max
+      group_by:
+      - col3
+      limit: 25.5
+


### PR DESCRIPTION
## Changes
This PR introduces built-in equality checks for aggregate values:
- `is_aggr_equal_to` checks that the aggregate value is equal to a provided limit
- `is_aggr_not_equal_to` checks that the aggregate value is not equal to a provided limit

### Linked issues
Resolves #369 

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [ ] added unit tests
- [x] added integration tests
