### PR TITLE
Pin GitHub URLs in docs to the latest released version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ lint:
 
 fmt:
 	hatch run fmt
+	hatch run update_github_urls
 
 test:
 	hatch run test

--- a/docs/dqx/docs/demos.mdx
+++ b/docs/dqx/docs/demos.mdx
@@ -7,11 +7,11 @@ import Admonition from '@theme/Admonition';
 #  Demos
 
 Import the following notebooks in the Databricks workspace to try DQX out:
-* [DQX Demo Notebook (library)](https://github.com/databrickslabs/dqx/blob/main/demos/dqx_demo_library.py) - demonstrates how to use DQX as a library.
-* [DQX Quick Start Demo Notebook (library)](https://github.com/databrickslabs/dqx/blob/main/demos/notebooks/dqx_quick_start_demo_library.ipynb) - quickstart on how to use DQX as a library.
-* [DQX Demo Notebook (tool)](https://github.com/databrickslabs/dqx/blob/main/demos/dqx_demo_tool.py) - demonstrates how to use DQX as a tool when installed in the workspace.
-* [DQX DLT Demo Notebook](https://github.com/databrickslabs/dqx/blob/main/demos/dqx_dlt_demo.py) - demonstrates how to use DQX with Delta Live Tables (DLT).
-* [DQX for PII Detection Notebook](https://github.com/databrickslabs/dqx/blob/main/demos/dqx_demo_pii_detection.py) - demonstrates how to use DQX to check data for Personally Identifiable Information (PII).
+* [DQX Demo Notebook (library)](https://github.com/databrickslabs/dqx/blob/v0.5.0/demos/dqx_demo_library.py) - demonstrates how to use DQX as a library.
+* [DQX Quick Start Demo Notebook (library)](https://github.com/databrickslabs/dqx/blob/v0.5.0/demos/notebooks/dqx_quick_start_demo_library.ipynb) - quickstart on how to use DQX as a library.
+* [DQX Demo Notebook (tool)](https://github.com/databrickslabs/dqx/blob/v0.5.0/demos/dqx_demo_tool.py) - demonstrates how to use DQX as a tool when installed in the workspace.
+* [DQX DLT Demo Notebook](https://github.com/databrickslabs/dqx/blob/v0.5.0/demos/dqx_dlt_demo.py) - demonstrates how to use DQX with Delta Live Tables (DLT).
+* [DQX for PII Detection Notebook](https://github.com/databrickslabs/dqx/blob/v0.5.0/demos/dqx_demo_pii_detection.py) - demonstrates how to use DQX to check data for Personally Identifiable Information (PII).
 
 <Admonition type="tip" title="Execution Environment">
 You don't have to run DQX from a Notebook. DQX can be run from any Python script as long as it runs on Databricks.

--- a/docs/dqx/docs/guide/quality_checks.mdx
+++ b/docs/dqx/docs/guide/quality_checks.mdx
@@ -703,7 +703,7 @@ Below is a sample output of a check as stored in a result column:
 ```
 
 The structure of the result columns is an array of struct containing the following fields
-(see the exact structure [here](https://github.com/databrickslabs/dqx/blob/main/src/databricks/labs/dqx/schema/dq_result_schema.py)):
+(see the exact structure [here](https://github.com/databrickslabs/dqx/blob/v0.5.0/src/databricks/labs/dqx/schema/dq_result_schema.py)):
 - `name`: name of the check (string type).
 - `message`: message describing the quality issue (string type).
 - `columns`: name of the column(s) where the quality issue was found (string type).

--- a/docs/dqx/docs/reference/quality_rules.mdx
+++ b/docs/dqx/docs/reference/quality_rules.mdx
@@ -6,7 +6,7 @@ import TabItem from '@theme/TabItem';
 
 This page provides a reference for the quality checks (rule functions) available in DQX.
 
-You can explore the implementation details of the check functions [here](https://github.com/databrickslabs/dqx/blob/main/src/databricks/labs/dqx/check_funcs.py).
+You can explore the implementation details of the check functions [here](https://github.com/databrickslabs/dqx/blob/v0.5.0/src/databricks/labs/dqx/check_funcs.py).
 
 ## Row-level checks reference
 
@@ -1883,7 +1883,7 @@ When using dataset-level checks, the filter condition is applied before aggregat
 ## Detecting Personally Identifiable Information (PII) using a Python function
 
 You can write custom check to detect Personally Identifiable Information (PII) in the input data. To use PII-detection libraries (e.g. Presidio),
-install any required dependencies, define a Spark UDF to detect PII, and use `make_condition` to call the UDF as a DQX check. See [DQX for PII Detection Notebook](https://github.com/databrickslabs/dqx/blob/main/demos/dqx_demo_pii_detection.py)
+install any required dependencies, define a Spark UDF to detect PII, and use `make_condition` to call the UDF as a DQX check. See [DQX for PII Detection Notebook](https://github.com/databrickslabs/dqx/blob/v0.5.0/demos/dqx_demo_pii_detection.py)
 for a full example.
 
 <Tabs>

--- a/docs/dqx/update_github_urls.py
+++ b/docs/dqx/update_github_urls.py
@@ -1,0 +1,43 @@
+import re
+from pathlib import Path
+
+
+def get_dqx_version(about_path: Path) -> str:
+    """Extract the version string from the __about__.py file."""
+    content = about_path.read_text()
+    match = re.search(r'__version__\s*=\s*"(?P<version>[\d.]+)"', content)
+    if not match:
+        raise ValueError(f"Version not found in {about_path}")
+    return match.group("version")
+
+
+def update_mdx_files(mdx_dir: Path, version: str):
+    """Update all .mdx files in the directory and subdirectories by replacing
+    GitHub URLs pointing to main branch to the versioned one."""
+    mdx_files = list(mdx_dir.rglob("*.mdx"))  # Recursive search
+
+    if not mdx_files:
+        return
+
+    pattern = re.compile(r"https://github.com/databrickslabs/dqx/blob/main/")
+    replacement = f"https://github.com/databrickslabs/dqx/blob/v{version}/"
+
+    for mdx_file in mdx_files:
+        content = mdx_file.read_text()
+        updated_content = pattern.sub(replacement, content)
+
+        if updated_content != content:
+            mdx_file.write_text(updated_content)
+            print(f"Updated GitHub URLs in {mdx_file} to point to the latest DQX released version")
+
+
+def main():
+    about_file = Path("src/databricks/labs/dqx/__about__.py")
+    mdx_dir = Path("docs/dqx/docs")
+
+    version = get_dqx_version(about_file)
+    update_mdx_files(mdx_dir, version)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/dqx/update_github_urls.py
+++ b/docs/dqx/update_github_urls.py
@@ -19,7 +19,7 @@ def update_mdx_files(mdx_dir: Path, version: str):
     if not mdx_files:
         return
 
-    pattern = re.compile(r"https://github.com/databrickslabs/dqx/blob/main/")
+    pattern = re.compile(r"https://github.com/databrickslabs/dqx/blob/(main|v\d+\.\d+\.\d+)/")
     replacement = f"https://github.com/databrickslabs/dqx/blob/v{version}/"
 
     for mdx_file in mdx_files:

--- a/docs/dqx/update_github_urls.py
+++ b/docs/dqx/update_github_urls.py
@@ -13,7 +13,7 @@ def get_dqx_version(about_path: Path) -> str:
 
 def update_mdx_files(mdx_dir: Path, version: str):
     """Update all .mdx files in the directory and subdirectories by replacing
-    GitHub URLs pointing to main branch to the versioned one."""
+    GitHub URLs pointing to source code in main branch to the versioned one."""
     mdx_files = list(mdx_dir.rglob("*.mdx"))  # Recursive search
 
     if not mdx_files:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ verify      = ["black --check .",
                "ruff check .",
                "mypy .",
                "pylint --output-format=colorized -j 0 src tests"]
+update_github_urls = "python docs/dqx/update_github_urls.py"
 
 [tool.isort]
 profile = "black"

--- a/src/databricks/labs/dqx/check_funcs.py
+++ b/src/databricks/labs/dqx/check_funcs.py
@@ -8,7 +8,7 @@ from pyspark.sql import Column, DataFrame, SparkSession
 from pyspark.sql.window import Window
 
 from databricks.labs.dqx.rule import register_rule
-from databricks.labs.dqx.utils import get_column_as_string
+from databricks.labs.dqx.utils import get_column_as_string, is_sql_query_safe
 
 
 def make_condition(condition: Column, message: Column | str, alias: str) -> Column:
@@ -729,6 +729,11 @@ def sql_query(
     if not merge_columns:
         raise ValueError("merge_columns must contain at least one column.")
 
+    if not is_sql_query_safe(query):
+        raise ValueError(
+            "Provided SQL query is not safe for execution. Please ensure it does not contain any unsafe operations."
+        )
+
     alias_name = name if name else "_".join(merge_columns) + f"_query_{condition_column}_violation"
 
     unique_str = uuid.uuid4().hex  # make sure any column added to the dataframe is unique
@@ -750,6 +755,12 @@ def sql_query(
             replacements[ref_name] = ref_name_unique
 
         query_resolved = _replace_template(query, replacements)
+        if not is_sql_query_safe(query_resolved):
+            # we only replace dict keys so there is no risk of SQL injection here,
+            # but we still want to ensure the query is safe to execute
+            raise ValueError(
+                "Resolved SQL query is not safe for execution. Please ensure it does not contain any unsafe operations."
+            )
 
         # Resolve the SQL query against the input DataFrame and any reference DataFrames
         user_query_df = spark.sql(query_resolved).select(
@@ -862,7 +873,6 @@ def _replace_template(sql: str, replacements: dict[str, str]) -> str:
     """
     Replace {{ template }} placeholders in sql with actual names, allowing for whitespace between braces.
     """
-    # TODO protect from SQL injection
     for key, val in replacements.items():
         pattern = r"\{\{\s*" + re.escape(key) + r"\s*\}\}"
         sql = re.sub(pattern, val, sql)

--- a/src/databricks/labs/dqx/utils.py
+++ b/src/databricks/labs/dqx/utils.py
@@ -145,3 +145,29 @@ def save_dataframe_as_table(
         query.awaitTermination()
     else:
         df.write.format("delta").mode(mode).options(**options).saveAsTable(table_name)
+
+
+def is_sql_query_safe(query: str) -> bool:
+    # Normalize the query by removing extra whitespace and converting to lowercase
+    normalized_query = re.sub(r"\s+", " ", query).strip().lower()
+
+    # Check for prohibited statements
+    forbidden_statements = [
+        "delete",
+        "insert",
+        "update",
+        "drop",
+        "truncate",
+        "alter",
+        "create",
+        "replace",
+        "grant",
+        "revoke",
+        "merge",
+        "use",
+        "refresh",
+        "analyze",
+        "optimize",
+        "zorder",
+    ]
+    return not any(re.search(rf"\b{kw}\b", normalized_query) for kw in forbidden_statements)

--- a/tests/unit/test_dataset_checks.py
+++ b/tests/unit/test_dataset_checks.py
@@ -77,3 +77,13 @@ def test_sql_query_missing_merge_columns():
             check_func=sql_query,
             check_func_kwargs={"query": "SELECT 1", "merge_columns": [], "condition_column": "condition"},
         )
+
+
+def test_sql_query_unsafe():
+    query = "SELECT * FROM {{ input }} JOIN {{ validname; DROP TABLE sensitive_data -- }} ON id = id"
+    with pytest.raises(ValueError, match="Provided SQL query is not safe for execution"):
+        DQDatasetRule(
+            criticality="error",
+            check_func=sql_query,
+            check_func_kwargs={"query": query, "merge_columns": ["col1"], "condition_column": "condition"},
+        )

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -2,7 +2,7 @@ from unittest.mock import Mock
 import pyspark.sql.functions as F
 import pytest
 
-from databricks.labs.dqx.utils import read_input_data, get_column_as_string
+from databricks.labs.dqx.utils import read_input_data, get_column_as_string, is_sql_query_safe
 
 
 def test_get_column_name():
@@ -94,3 +94,62 @@ def test_valid_3_level_table_namespace():
     input_location = "catalog.schema.table"
     input_format = None
     assert read_input_data(Mock(), input_location, input_format)
+
+
+def test_safe_query_with_similar_names():
+    # Should be safe: keywords appear only as part of column or table names
+    assert is_sql_query_safe("SELECT insert_, _delete, update_, * FROM insert_users_delete_update")
+
+
+@pytest.mark.parametrize(
+    "forbidden_statements",
+    [
+        "delete",
+        "insert",
+        "update",
+        "drop",
+        "truncate",
+        "alter",
+        "create",
+        "replace",
+        "grant",
+        "revoke",
+        "merge",
+        "use",
+        "refresh",
+        "analyze",
+        "optimize",
+        "zorder",
+    ],
+)
+def test_query_with_forbidden_commands(forbidden_statements):
+    query = f"{forbidden_statements.upper()} something FROM table"
+    assert not is_sql_query_safe(query), f"Query with '{forbidden_statements}' should be unsafe"
+
+
+def test_case_insensitivity():
+    assert not is_sql_query_safe("dElEtE FROM users")
+    assert not is_sql_query_safe("InSeRT INTO users (id) VALUES (1)")
+    assert not is_sql_query_safe("uPdAtE users SET name = 'Charlie'")
+
+
+def test_query_with_comments_containing_keywords():
+    # Should still be safe because we're not removing SQL comments
+    # but in practice this would be flagged — optional to allow or disallow
+    assert not is_sql_query_safe("SELECT * FROM users -- delete everything later")
+
+
+def test_keyword_as_substring():
+    assert is_sql_query_safe("SELECT * FROM deleted_users_log WHERE update_flag = true")
+
+
+def test_multiple_statements_in_one_query():
+    assert not is_sql_query_safe("SELECT * FROM users; DELETE FROM users")
+
+
+def test_blank_query():
+    assert is_sql_query_safe("  ")
+
+
+def test_mixed_content():
+    assert not is_sql_query_safe("WITH cte AS (UPDATE users SET x=1) SELECT * FROM cte")


### PR DESCRIPTION
## Changes

Run script to update Github URLs for source code in docs as part of fmt command to pin it to the latest released version instead of main. This is to protect from situation that changes to demos are merged to main branch but new version is not yet released. We currently link demos from the main branch which is incorrect. The links to any source code should point to the latest released version.

The script is run as part of fmt, so user can review any changes before commit.
This will also force updating the links during the release automatically.

For example: docs should point to https://github.com/databrickslabs/dqx/blob/v0.5.0/demos/dqx_demo_library.py
instead of: https://github.com/databrickslabs/dqx/blob/main/demos/dqx_demo_library.py

### Linked issues

Resolves #389 

### Tests

- [x] manually tested
- [ ] added unit tests
- [ ] added integration tests
