### PR TITLE
Add Github Action to check if all commits are signed

### DIFF
--- a/.github/workflows/check-if-commit-signed.yml
+++ b/.github/workflows/check-if-commit-signed.yml
@@ -1,0 +1,18 @@
+name: Check signed commits in PR
+on: pull_request_target
+
+jobs:
+  check-signed-commits:
+    name: Check signed commits in PR
+    runs-on:
+      group: databrickslabs-protected-runner-group
+      labels: linux-ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Check signed commits in PR
+        uses: 1Password/check-signed-commits-action@v1
+        with:
+          comment: |
+            All commits in PR should be signed ('git commit -S ...'). See https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary -->

With this GH Action, contributors will be warned earlier that their PR contains unsigned commits.  This action already works at `sandbox` repo

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #..

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
