### PR TITLE
Fix missing check_criticality attribute

### DIFF
--- a/src/databricks/labs/dqx/engine.py
+++ b/src/databricks/labs/dqx/engine.py
@@ -400,7 +400,7 @@ class DQEngineCore(DQEngineCoreBase):
         :param criticality: criticality
         :return: list of check columns
         """
-        return [check for check in checks if check.check_criticality == criticality]
+        return [check for check in checks if check.criticality == criticality]
 
     def _append_empty_checks(self, df: DataFrame) -> DataFrame:
         """Append empty checks at the end of dataframe.


### PR DESCRIPTION
## Changes
Replace the `check_criticality` attribute in the `_get_check_columns` function to `criticality`. There is no other parts of code that use / create that `check_criticality` attribute -- so this is still a guess of the fix.

Let me know if you want me to make tests and how to structure them.

### Linked issues
Resolves https://github.com/databrickslabs/dqx/issues/448

### Tests
Not tested yet. I need help in configuring codespace environment.
