### PR TITLE
Feat add ip address validation

### DIFF
--- a/src/databricks/labs/dqx/check_funcs.py
+++ b/src/databricks/labs/dqx/check_funcs.py
@@ -528,6 +528,21 @@ def is_valid_timestamp(column: str | Column, timestamp_format: str | None = None
         f"{col_str_norm}_is_not_valid_timestamp",
     )
 
+@register_rule("row")
+def is_valid_ipv4_address(column: str | Column) -> Column:
+    """Checks whether the values in the input column have valid IPv4 address formats.
+
+    :param column: column to check; can be a string column name or a column expression
+    :return: Column object for condition
+    """
+    col_str_norm, col_expr_str, col_expr = _get_norm_column_and_expr(column)
+    condition = ~col_expr.rlike("^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$")
+
+    return make_condition(
+        condition,
+        f"Column '{col_expr_str}' is not a valid IPv4 address",
+        f"{col_str_norm}_is_not_valid_ipv4_address",
+    )
 
 @register_rule("dataset")
 def is_unique(

--- a/src/databricks/labs/dqx/check_funcs.py
+++ b/src/databricks/labs/dqx/check_funcs.py
@@ -528,6 +528,7 @@ def is_valid_timestamp(column: str | Column, timestamp_format: str | None = None
         f"{col_str_norm}_is_not_valid_timestamp",
     )
 
+
 @register_rule("row")
 def is_valid_ipv4_address(column: str | Column) -> Column:
     """Checks whether the values in the input column have valid IPv4 address formats.
@@ -536,13 +537,14 @@ def is_valid_ipv4_address(column: str | Column) -> Column:
     :return: Column object for condition
     """
     col_str_norm, col_expr_str, col_expr = _get_norm_column_and_expr(column)
-    condition = ~col_expr.rlike("^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$")
+    condition = ~col_expr.rlike(r"^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}$")
 
     return make_condition(
         condition,
         f"Column '{col_expr_str}' is not a valid IPv4 address",
         f"{col_str_norm}_is_not_valid_ipv4_address",
     )
+
 
 @register_rule("dataset")
 def is_unique(

--- a/tests/integration/test_apply_checks.py
+++ b/tests/integration/test_apply_checks.py
@@ -382,19 +382,19 @@ def test_foreign_key_check_on_composite_keys(ws, spark):
           check:
             function: foreign_key
             arguments:
-              columns: 
+              columns:
               - a
-              ref_columns: 
+              ref_columns:
               - ref_a
               ref_df_name: ref_df
         - criticality: error
           check:
             function: foreign_key
             arguments:
-              columns: 
+              columns:
               - a
               - b
-              ref_columns: 
+              ref_columns:
               - ref_a
               - ref_b
               ref_df_name: ref_df2
@@ -494,10 +494,10 @@ def test_foreign_key_check_on_composite_keys_negate(ws, spark):
           check:
             function: foreign_key
             arguments:
-              columns: 
+              columns:
               - a
               - b
-              ref_columns: 
+              ref_columns:
               - ref_a
               - ref_b
               ref_df_name: ref_df2
@@ -601,9 +601,9 @@ def test_foreign_key_check_yaml(ws, spark):
           check:
             function: foreign_key
             arguments:
-              columns: 
+              columns:
               - a
-              ref_columns: 
+              ref_columns:
               - {ref_column}
               ref_df_name: ref_df
           user_metadata:
@@ -614,9 +614,9 @@ def test_foreign_key_check_yaml(ws, spark):
           check:
             function: foreign_key
             arguments:
-              columns: 
+              columns:
               - a
-              ref_columns: 
+              ref_columns:
               - {ref_column}
               ref_df_name: ref_df
         """
@@ -2540,7 +2540,7 @@ def test_apply_checks_with_sql_query_and_ref_df(ws, spark):
                     sensor.*,
                     COALESCE(specs.min_threshold, 100) AS effective_threshold
                 FROM {{ sensor }} sensor
-                LEFT JOIN {{ sensor_specs }} specs 
+                LEFT JOIN {{ sensor_specs }} specs
                     ON sensor.sensor_id = specs.sensor_id
             )
             SELECT
@@ -2646,7 +2646,7 @@ def test_apply_checks_with_sql_query_and_ref_table(ws, spark):
                         sensor.*,
                         COALESCE(specs.min_threshold, 100) AS effective_threshold
                     FROM {{ sensor }} sensor
-                    LEFT JOIN {{ sensor_specs }} specs 
+                    LEFT JOIN {{ sensor_specs }} specs
                         ON sensor.sensor_id = specs.sensor_id
                 )
                 SELECT
@@ -4201,7 +4201,7 @@ def test_apply_checks_all_row_checks_as_yaml_with_streaming(ws, make_schema, mak
 
     schema = (
         "col1: string, col2: int, col3: int, col4 array<int>, col5: date, col6: timestamp, "
-        "col7: map<string, int>, col8: struct<field1: int>"
+        "col7: map<string, int>, col8: struct<field1: int>, col9: string"
     )
     test_df = spark.createDataFrame(
         [
@@ -4214,6 +4214,7 @@ def test_apply_checks_all_row_checks_as_yaml_with_streaming(ws, make_schema, mak
                 datetime(2025, 1, 12, 1, 0, 0),
                 {"key1": 1},
                 {"field1": 1},
+                "192.168.1.1",
             ],
             [
                 "val2",
@@ -4224,6 +4225,7 @@ def test_apply_checks_all_row_checks_as_yaml_with_streaming(ws, make_schema, mak
                 datetime(2025, 1, 12, 2, 0, 0),
                 {"key1": 1},
                 {"field1": 1},
+                "0.0.0.0",
             ],
             [
                 "val3",
@@ -4234,6 +4236,7 @@ def test_apply_checks_all_row_checks_as_yaml_with_streaming(ws, make_schema, mak
                 datetime(2025, 1, 12, 3, 0, 0),
                 {"key1": 1},
                 {"field1": 1},
+                "255.255.255.255",
             ],
         ],
         schema,

--- a/tests/integration/test_apply_checks.py
+++ b/tests/integration/test_apply_checks.py
@@ -4325,7 +4325,7 @@ def test_apply_checks_all_checks_as_yaml(ws, spark):
 
     schema = (
         "col1: string, col2: int, col3: int, col4 array<int>, col5: date, col6: timestamp, "
-        "col7: map<string, int>, col8: struct<field1: int>"
+        "col7: map<string, int>, col8: struct<field1: int>, col9: string"
     )
     test_df = spark.createDataFrame(
         [
@@ -4338,6 +4338,7 @@ def test_apply_checks_all_checks_as_yaml(ws, spark):
                 datetime(2025, 1, 12, 1, 0, 0),
                 {"key1": 1},
                 {"field1": 1},
+                "255.255.255.255",
             ],
             [
                 "val2",
@@ -4348,6 +4349,7 @@ def test_apply_checks_all_checks_as_yaml(ws, spark):
                 datetime(2025, 1, 12, 2, 0, 0),
                 {"key1": 1},
                 {"field1": 1},
+                "127.0.0.1",
             ],
             [
                 "val3",
@@ -4358,6 +4360,7 @@ def test_apply_checks_all_checks_as_yaml(ws, spark):
                 datetime(2025, 1, 12, 3, 0, 0),
                 {"key1": 1},
                 {"field1": 1},
+                "0.0.0.0",
             ],
         ],
         schema,
@@ -4380,6 +4383,7 @@ def test_apply_checks_all_checks_as_yaml(ws, spark):
                 datetime(2025, 1, 12, 1, 0, 0),
                 {"key1": 1},
                 {"field1": 1},
+                "255.255.255.255",
                 None,
                 None,
             ],
@@ -4392,6 +4396,7 @@ def test_apply_checks_all_checks_as_yaml(ws, spark):
                 datetime(2025, 1, 12, 2, 0, 0),
                 {"key1": 1},
                 {"field1": 1},
+                "127.0.0.1",
                 None,
                 None,
             ],
@@ -4404,6 +4409,7 @@ def test_apply_checks_all_checks_as_yaml(ws, spark):
                 datetime(2025, 1, 12, 3, 0, 0),
                 {"key1": 1},
                 {"field1": 1},
+                "0.0.0.0",
                 None,
                 None,
             ],
@@ -4889,13 +4895,20 @@ def test_apply_checks_all_checks_using_classes(ws, spark):
                 F.try_element_at("col4", F.lit(1)),  # array col
             ],
         ).get_rules(),
+        # is_valid_ipv4_address check
+        DQRowRule(
+            criticality="error",
+            check_func=check_funcs.is_valid_ipv4_address,
+            column="col9",
+            user_metadata={"tag1": "value4", "tag2": "030"},
+        ),
     ]
 
     dq_engine = DQEngine(ws)
 
     schema = (
         "col1: string, col2: int, col3: int, col4 array<int>, col5: date, col6: timestamp, "
-        "col7: map<string, int>, col8: struct<field1: int>"
+        "col7: map<string, int>, col8: struct<field1: int>, col9: string"
     )
     test_df = spark.createDataFrame(
         [
@@ -4908,6 +4921,7 @@ def test_apply_checks_all_checks_using_classes(ws, spark):
                 datetime(2025, 1, 12, 1, 0, 0),
                 {"key1": 1},
                 {"field1": 1},
+                "255.255.255.255",
             ],
             [
                 "val2",
@@ -4918,6 +4932,7 @@ def test_apply_checks_all_checks_using_classes(ws, spark):
                 datetime(2025, 1, 12, 2, 0, 0),
                 {"key1": 1},
                 {"field1": 1},
+                "0.0.0.0",
             ],
             [
                 "val3",
@@ -4928,6 +4943,7 @@ def test_apply_checks_all_checks_using_classes(ws, spark):
                 datetime(2025, 1, 12, 3, 0, 0),
                 {"key1": 1},
                 {"field1": 1},
+                "127.0.0.1",
             ],
         ],
         schema,
@@ -4947,6 +4963,7 @@ def test_apply_checks_all_checks_using_classes(ws, spark):
                 datetime(2025, 1, 12, 1, 0, 0),
                 {"key1": 1},
                 {"field1": 1},
+                "255.255.255.255",
                 None,
                 None,
             ],
@@ -4959,6 +4976,7 @@ def test_apply_checks_all_checks_using_classes(ws, spark):
                 datetime(2025, 1, 12, 2, 0, 0),
                 {"key1": 1},
                 {"field1": 1},
+                "0.0.0.0",
                 None,
                 None,
             ],
@@ -4971,6 +4989,7 @@ def test_apply_checks_all_checks_using_classes(ws, spark):
                 datetime(2025, 1, 12, 3, 0, 0),
                 {"key1": 1},
                 {"field1": 1},
+                "127.0.0.1",
                 None,
                 None,
             ],

--- a/tests/integration/test_row_checks.py
+++ b/tests/integration/test_row_checks.py
@@ -1056,16 +1056,16 @@ def test_col_is_valid_in_ipv4_address(spark):
 
     actual = test_df.select(is_valid_ipv4_address("a"))
 
-    checked_schema = "a_is_valid_ipv4_address: string"
+    checked_schema = "a_is_not_valid_ipv4_address: string"
 
     expected = spark.createDataFrame(
         [
             [None],
-            ["Value '192.168.01.1' in Column 'a' is not a valid IPv4 address"],
+            ["Column 'a' is not a valid IPv4 address"],
             [None],
-            ["Value '192.168.1' in Column 'a' is not a valid IPv4 address"],
-            ["Value 'abc.def.ghi.jkl' in Column 'a' is not a valid IPv4 address"],
+            ["Column 'a' is not a valid IPv4 address"],
+            ["Column 'a' is not a valid IPv4 address"],
         ],
         checked_schema,
     )
-    assert actual.select("a_is_valid_ipv4_address") != expected.select("a_is_valid_ipv4_address")
+    assert_df_equality(actual, expected, ignore_nullable=True)

--- a/tests/resources/all_row_checks.yaml
+++ b/tests/resources/all_row_checks.yaml
@@ -330,3 +330,9 @@
     - try_element_at(col7, 'key1') # map col
     - try_element_at(col4, 1) # array col
 
+# is_valid_ipv4_address check
+- criticality: error
+  check:
+    function: is_valid_ipv4_address
+    arguments:
+      column: col9

--- a/tests/unit/test_build_rules.py
+++ b/tests/unit/test_build_rules.py
@@ -12,6 +12,7 @@ from databricks.labs.dqx.check_funcs import (
     is_aggr_not_greater_than,
     is_aggr_not_less_than,
     foreign_key,
+    is_valid_ipv4_address,
 )
 from databricks.labs.dqx.rule import (
     DQForEachColRule,
@@ -225,6 +226,7 @@ def test_build_rules():
         DQDatasetRule(
             criticality="warn", check_func=is_unique, columns=["j"], check_func_kwargs={"columns": ["j_as_kwargs"]}
         ),
+        DQRowRule(criticality="warn", check_func=is_valid_ipv4_address, column="g"),
     ]
 
     expected_rules = [
@@ -430,6 +432,12 @@ def test_build_rules():
             columns=["j"],
             check_func_kwargs={"columns": ["j_as_kwargs"]},
         ),
+        DQRowRule(
+            name="g_is_not_valid_ipv4_address",
+            criticality="warn",
+            check_func=is_valid_ipv4_address,
+            column="g",
+        ),
     ]
 
     assert pprint.pformat(actual_rules) == pprint.pformat(expected_rules)
@@ -556,6 +564,11 @@ def test_build_rules_by_metadata():
                 "for_each_column": [["a"], ["c"]],
                 "arguments": {"ref_columns": ["ref_a"], "ref_df_name": "ref_df_key"},
             },
+        },
+        {
+            "name": "is_not_valid_ipv4_address",
+            "criticality": "error",
+            "check": {"function": "is_valid_ipv4_address", "arguments": {"column": "a"}},
         },
     ]
 
@@ -760,6 +773,12 @@ def test_build_rules_by_metadata():
                 "ref_columns": ["ref_a"],
                 "ref_df_name": "ref_df_key",
             },
+        ),
+        DQRowRule(
+            name="is_not_valid_ipv4_address",
+            criticality="error",
+            check_func=is_valid_ipv4_address,
+            column="a",
         ),
     ]
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary -->
- Added a new row check called `is_valid_in_ipv4_address`. I used an IPv4 address, as I also have an IPv6 address, but IPv4 is more common. Also, another check can be created for IPv6, if the need arises

<img width="981" height="588" alt="image" src="https://github.com/user-attachments/assets/28a40cc0-bccd-4560-888e-6c2c3d711209" />

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #452 

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [x] added unit tests
- [x] added integration tests
