### PR TITLE
Fix datetime rounding logic and ensure round=False is respected

### DIFF
--- a/src/databricks/labs/dqx/profiler/profiler.py
+++ b/src/databricks/labs/dqx/profiler/profiler.py
@@ -675,10 +675,21 @@ class DQProfiler(DQEngineBase):
 
     @staticmethod
     def _round_datetime(value: datetime.datetime, direction: str) -> datetime.datetime:
+        """
+        Rounds a datetime value to midnight based on the specified direction.
+
+        :param value: The datetime value to round.
+        :param direction: The rounding direction ("up" or "down").
+        :return: The rounded datetime value.
+        """
         if direction == "down":
             return value.replace(hour=0, minute=0, second=0, microsecond=0)
         if direction == "up":
-            return value.replace(hour=0, minute=0, second=0, microsecond=0) + datetime.timedelta(days=1)
+            try:
+                return value.replace(hour=0, minute=0, second=0, microsecond=0) + datetime.timedelta(days=1)
+            except OverflowError:
+                logger.warning("Rounding datetime up caused overflow; returning datetime.max instead.")
+                return datetime.datetime.max
         return value
 
     @staticmethod

--- a/src/databricks/labs/dqx/profiler/profiler.py
+++ b/src/databricks/labs/dqx/profiler/profiler.py
@@ -576,13 +576,13 @@ class DQProfiler(DQEngineBase):
                     f"stddev={stddev}, min={metrics.get('min')}"
                 )
             # we need to preserve type at the end
-            min_limit, max_limit = self._adjust_min_max_limits(min_limit, max_limit, avg, typ, metrics)
+            min_limit, max_limit = self._adjust_min_max_limits(min_limit, max_limit, avg, typ, metrics, opts)
         else:
             logger.info(f"Can't get min/max for field {col_name}")
         return descr, max_limit, min_limit
 
     def _adjust_min_max_limits(
-        self, min_limit: Any, max_limit: Any, avg: Any, typ: T.DataType, metrics: dict[str, Any]
+        self, min_limit: Any, max_limit: Any, avg: Any, typ: T.DataType, metrics: dict[str, Any], opts: dict[str, Any]
     ) -> tuple[Any, Any]:
         """
         Adjusts the minimum and maximum limits based on the data type of the column.
@@ -592,11 +592,12 @@ class DQProfiler(DQEngineBase):
         :param avg: The average value of the column.
         :param typ: The PySpark data type of the column.
         :param metrics: A dictionary containing the calculated metrics.
+        :param opts: A dictionary of options for min/max limit adjustment.
         :return: A tuple containing the adjusted minimum and maximum limits.
         """
         if isinstance(typ, T.IntegralType):
-            min_limit = int(self._round_value(min_limit, "down", {"round": True}))
-            max_limit = int(self._round_value(max_limit, "up", {"round": True}))
+            min_limit = int(self._round_value(min_limit, "down", opts))
+            max_limit = int(self._round_value(max_limit, "up", opts))
         elif typ == T.DateType():
             min_limit = datetime.date.fromtimestamp(int(min_limit))
             max_limit = datetime.date.fromtimestamp(int(max_limit))
@@ -604,8 +605,8 @@ class DQProfiler(DQEngineBase):
             metrics["max"] = datetime.date.fromtimestamp(int(metrics["max"]))
             metrics["mean"] = datetime.date.fromtimestamp(int(avg))
         elif typ == T.TimestampType():
-            min_limit = self._round_value(datetime.datetime.fromtimestamp(int(min_limit)), "down", {"round": True})
-            max_limit = self._round_value(datetime.datetime.fromtimestamp(int(max_limit)), "up", {"round": True})
+            min_limit = self._round_value(datetime.datetime.fromtimestamp(int(min_limit)), "down", opts)
+            max_limit = self._round_value(datetime.datetime.fromtimestamp(int(max_limit)), "up", opts)
             metrics["min"] = datetime.datetime.fromtimestamp(int(metrics["min"]))
             metrics["max"] = datetime.datetime.fromtimestamp(int(metrics["max"]))
             metrics["mean"] = datetime.datetime.fromtimestamp(int(avg))


### PR DESCRIPTION
## TL;DR

Fixes two issues in datetime profiling:
- `round=False` option was not respected due to missing `opts` propagation.
- `datetime.max` caused an `OverflowError` when rounded up — now safely handled.

## Changes

- Fixes a bug where `opts={"round": False}` was ignored during min/max adjustment due to `opts` not being passed to `_adjust_min_max_limits`.
- Prevents `OverflowError` when attempting to round up `datetime.datetime.max` by capping the result to `datetime.datetime.max`.
- Adds a warning log when overflow is caught during datetime rounding.

### Linked issues

Resolves [#475](https://github.com/databrickslabs/dqx/issues/475)

### Tests

- [x] manually tested
- [ ] added unit tests
- [ ] added integration tests

> A unit test for `_round_datetime` was considered but intentionally omitted to avoid accessing a protected method directly. The logic is indirectly covered by existing profiling workflows.
