### PR TITLE
Fix/round datetime midnight

### DIFF
--- a/src/databricks/labs/dqx/profiler/profiler.py
+++ b/src/databricks/labs/dqx/profiler/profiler.py
@@ -703,7 +703,6 @@ class DQProfiler(DQEngineBase):
             except OverflowError:
                 logger.warning("Rounding datetime up caused overflow; returning datetime.max instead.")
                 return datetime.datetime.max
-        
         raise ValueError(f"Invalid rounding direction: {direction}. Use 'up' or 'down'.")
 
     @staticmethod

--- a/src/databricks/labs/dqx/profiler/profiler.py
+++ b/src/databricks/labs/dqx/profiler/profiler.py
@@ -681,19 +681,30 @@ class DQProfiler(DQEngineBase):
         """
         Rounds a datetime value to midnight based on the specified direction.
 
+        - "down" → truncate to midnight (00:00:00).
+        - "up" → return the next midnight unless value is already midnight.
+        - Raises ValueError for invalid direction.
+
         :param value: The datetime value to round.
         :param direction: The rounding direction ("up" or "down").
         :return: The rounded datetime value.
+        :raises ValueError: If direction is not 'up' or 'down'.
         """
+        midnight = value.replace(hour=0, minute=0, second=0, microsecond=0)
+
         if direction == "down":
-            return value.replace(hour=0, minute=0, second=0, microsecond=0)
+            return midnight
+
         if direction == "up":
+            if midnight == value:
+                return value
             try:
-                return value.replace(hour=0, minute=0, second=0, microsecond=0) + datetime.timedelta(days=1)
+                return midnight + datetime.timedelta(days=1)
             except OverflowError:
                 logger.warning("Rounding datetime up caused overflow; returning datetime.max instead.")
                 return datetime.datetime.max
-        return value
+        
+        raise ValueError(f"Invalid rounding direction: {direction}. Use 'up' or 'down'.")
 
     @staticmethod
     def _round_float(value: float, direction: str) -> float:

--- a/tests/integration/test_profiler.py
+++ b/tests/integration/test_profiler.py
@@ -199,6 +199,8 @@ def test_profiler_rounding_midnight_behavior(spark, ws):
     ]
     assert len(stats.keys()) > 0
     assert rules == expected_rules
+
+
 def test_profiler_non_default_profile_options(spark, ws):
     inp_schema = T.StructType(
         [

--- a/tests/integration/test_profiler.py
+++ b/tests/integration/test_profiler.py
@@ -200,7 +200,6 @@ def test_profiler_rounding_midnight_behavior(spark, ws):
     assert len(stats.keys()) > 0
     assert rules == expected_rules
     
-    
 def test_profiler_non_default_profile_options(spark, ws):
     inp_schema = T.StructType(
         [

--- a/tests/integration/test_profiler.py
+++ b/tests/integration/test_profiler.py
@@ -199,7 +199,6 @@ def test_profiler_rounding_midnight_behavior(spark, ws):
     ]
     assert len(stats.keys()) > 0
     assert rules == expected_rules
-    
 def test_profiler_non_default_profile_options(spark, ws):
     inp_schema = T.StructType(
         [

--- a/tests/integration/test_profiler.py
+++ b/tests/integration/test_profiler.py
@@ -197,7 +197,6 @@ def test_profiler_rounding_midnight_behavior(spark, ws):
         ),
         DQProfile(name="is_not_null", column="b1", description=None, parameters=None),
     ]
-    print(stats)
     assert len(stats.keys()) > 0
     assert rules == expected_rules
     


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary -->
This PR improves the `_round_datetime` method by preserving midnight values during "up" rounding. Previously, even midnight timestamps were rounded to the next day, which could produce unexpected results in min/max rule generation for timestamp fields. Now, if the input datetime is already at midnight, it remains unchanged when rounded "up".

This update also adds an integration test (`test_profiler_rounding_midnight_behavior`) to verify this behavior within the data quality profiling logic.

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves [#516](https://github.com/databrickslabs/dqx/issues/516)

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [ ] added unit tests
- [x] added integration tests
- [ ] added end-to-end tests
