### PR TITLE
Support end-to-end checking for multiple tables

### DIFF
--- a/demos/dqx_demo_tool.py
+++ b/demos/dqx_demo_tool.py
@@ -96,7 +96,7 @@ from databricks.labs.dqx.profiler.generator import DQGenerator
 from databricks.labs.dqx.engine import DQEngine
 from databricks.labs.dqx.config import InstallationChecksStorageConfig, WorkspaceFileChecksStorageConfig
 from databricks.labs.dqx.config_loader import RunConfigLoader
-from databricks.labs.dqx.utils import read_input_data
+from databricks.labs.dqx.io import read_input_data
 from databricks.sdk import WorkspaceClient
 
 

--- a/demos/dqx_multi_table_demo.py
+++ b/demos/dqx_multi_table_demo.py
@@ -27,7 +27,7 @@ else:
 
 # COMMAND ----------
 
-from databricks.labs.dqx.config import TableCheckConfig, InputConfig, OutputConfig
+from databricks.labs.dqx.config import ApplyChecksConfig, InputConfig, OutputConfig
 from databricks.labs.dqx.engine import DQEngine
 from databricks.labs.dqx.rule import DQRowRule
 from databricks.labs.dqx import check_funcs
@@ -125,15 +125,15 @@ order_checks = [
     }
 ]
 
-# Define the table configurations
-table_configs = [
-    TableCheckConfig(
+# Define the configs
+configs = [
+    ApplyChecksConfig(
         input_config=InputConfig(location=f"{demo_catalog_name}.{demo_schema_name}.users"),
         output_config=OutputConfig(location=f"{demo_catalog_name}.{demo_schema_name}.users_checked"),
         quarantine_config=OutputConfig(location=f"{demo_catalog_name}.{demo_schema_name}.users_quarantine"),
         checks=user_checks
     ),
-    TableCheckConfig(
+    ApplyChecksConfig(
         input_config=InputConfig(location=f"{demo_catalog_name}.{demo_schema_name}.orders"),
         output_config=OutputConfig(location=f"{demo_catalog_name}.{demo_schema_name}.orders_checked"),
         quarantine_config=OutputConfig(location=f"{demo_catalog_name}.{demo_schema_name}.orders_quarantine"),
@@ -143,8 +143,7 @@ table_configs = [
 
 # Apply checks to multiple tables and save the results
 dq_engine.apply_checks_and_save_in_tables(
-    table_configs=table_configs,
-    max_parallelism=4
+    configs=configs, max_parallelism=4
 )
 
 display(spark.table(f"{demo_catalog_name}.{demo_schema_name}.users_checked"))
@@ -188,15 +187,15 @@ order_rule_checks = [
     )
 ]
 
-# Define the table configurations
-table_configs = [
-    TableCheckConfig(
+# Define the configs
+configs = [
+    ApplyChecksConfig(
         input_config=InputConfig(location=f"{demo_catalog_name}.{demo_schema_name}.users"),
         output_config=OutputConfig(location=f"{demo_catalog_name}.{demo_schema_name}.users_validated"),
         quarantine_config=OutputConfig(location=f"{demo_catalog_name}.{demo_schema_name}.users_issues"),
         checks=user_rule_checks
     ),
-    TableCheckConfig(
+    ApplyChecksConfig(
         input_config=InputConfig(location=f"{demo_catalog_name}.{demo_schema_name}.orders"),
         output_config=OutputConfig(location=f"{demo_catalog_name}.{demo_schema_name}.orders_validated"),
         quarantine_config=OutputConfig(location=f"{demo_catalog_name}.{demo_schema_name}.orders_issues"),
@@ -206,8 +205,7 @@ table_configs = [
 
 # Apply checks to multiple tables and save the results
 dq_engine.apply_checks_and_save_in_tables(
-    table_configs=table_configs,
-    max_parallelism=4
+    configs=configs, max_parallelism=4
 )
 
 display(spark.table(f"{demo_catalog_name}.{demo_schema_name}.users_validated"))
@@ -236,9 +234,9 @@ for i in range(1, 6):  # Create 5 sample tables
     )
     sample_df.write.mode("overwrite").saveAsTable(f"{demo_catalog_name}.{demo_schema_name}.demo_table_{i}")
 
-# Create a larger set of table configurations for demonstration
-production_tables = [
-    TableCheckConfig(
+# Create a configs for multiple tables in a list
+configs = [
+    ApplyChecksConfig(
         input_config=InputConfig(location=f"{demo_catalog_name}.{demo_schema_name}.demo_table_{i}"),
         output_config=OutputConfig(location=f"{demo_catalog_name}.{demo_schema_name}.demo_table_{i}_validated"),
         checks=[
@@ -266,8 +264,7 @@ production_tables = [
 
 # Apply checks to multiple tables and save the results
 dq_engine.apply_checks_and_save_in_tables(
-    table_configs=production_tables,
-    max_parallelism=3
+    configs=configs, max_parallelism=3
 )
 
 display(spark.table(f"{demo_catalog_name}.{demo_schema_name}.demo_table_5_validated"))

--- a/demos/dqx_multi_table_demo.py
+++ b/demos/dqx_multi_table_demo.py
@@ -1,0 +1,273 @@
+# Databricks notebook source
+# MAGIC %md
+# MAGIC # DQX Multi-Table Data Quality Checks Demo
+# MAGIC 
+# MAGIC This notebook demonstrates how to apply data quality checks to multiple tables using DQX.
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Installing DQX
+
+# COMMAND ----------
+
+dbutils.widgets.text("test_library_ref", "", "Test Library Ref")
+
+if dbutils.widgets.get("test_library_ref") != "":
+    %pip install '{dbutils.widgets.get("test_library_ref")}'
+else:
+    %pip install databricks-labs-dqx
+
+%restart_python
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Setup and Configuration
+
+# COMMAND ----------
+
+from databricks.labs.dqx.config import TableCheckConfig, InputConfig, OutputConfig
+from databricks.labs.dqx.engine import DQEngine
+from databricks.labs.dqx.rule import DQRowRule
+from databricks.labs.dqx import check_funcs
+from databricks.sdk import WorkspaceClient
+
+# Default configuration values
+default_catalog = "main"
+default_schema = "default"
+
+# Create widgets for configuration
+dbutils.widgets.text("demo_catalog_name", default_catalog, "Catalog Name")
+dbutils.widgets.text("demo_schema_name", default_schema, "Schema Name")
+
+# Get configuration values
+demo_catalog_name = dbutils.widgets.get("demo_catalog_name")
+demo_schema_name = dbutils.widgets.get("demo_schema_name")
+
+print(f"Using catalog: {demo_catalog_name}")
+print(f"Using schema: {demo_schema_name}")
+
+# Initialize the DQX engine
+ws = WorkspaceClient()
+dq_engine = DQEngine(ws)
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Checking multiple tables using Dictionary-Based Checks (Metadata)
+
+# COMMAND ----------
+
+# Create a sample users table
+users_data = [
+    (1, "john@email.com", "John Doe", "2023-01-01"),
+    (2, "invalid-email", "Jane Smith", "2023-02-01"), 
+    (3, "bob@email.com", "Bob Wilson", "2023-03-01"),
+    (None, "alice@email.com", "Alice Brown", "2023-04-01")
+]
+
+users_df = spark.createDataFrame(
+    users_data, 
+    schema="user_id int, email string, name string, created_on date"
+)
+users_df.write.mode("overwrite").saveAsTable(f"{demo_catalog_name}.{demo_schema_name}.users")
+
+# Create a sample orders table
+orders_data = [
+    (1, 1, 100.50, "2023-01-15"),
+    (2, 2, -10.00, "2023-02-15"),
+    (3, 3, 75.25, "2023-03-15"),
+    (None, 4, 50.00, "2023-04-15")
+]
+
+orders_df = spark.createDataFrame(
+    orders_data,
+    schema="order_id int, user_id int, total_amount double, order_on date"
+)
+orders_df.write.mode("overwrite").saveAsTable(f"{demo_catalog_name}.{demo_schema_name}.orders")
+
+# Define checks for different tables using dictionaries
+user_checks = [
+    {
+        "criticality": "error",
+        "check": {
+            "function": "is_not_null",
+            "arguments": {"column": "user_id"}
+        }
+    },
+    {
+        "criticality": "warn", 
+        "check": {
+            "function": "regex_match",
+            "arguments": {
+                "column": "email",
+                "pattern": r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$"
+            }
+        }
+    }
+]
+
+order_checks = [
+    {
+        "criticality": "error",
+        "check": {
+            "function": "is_not_null",
+            "arguments": {"column": "order_id"}
+        }
+    },
+    {
+        "criticality": "error",
+        "check": {
+            "function": "is_not_less_than",
+            "arguments": {"column": "total_amount", "min_value": 0}
+        }
+    }
+]
+
+# Define the table configurations
+table_configs = [
+    TableCheckConfig(
+        input_config=InputConfig(location=f"{demo_catalog_name}.{demo_schema_name}.users"),
+        output_config=OutputConfig(location=f"{demo_catalog_name}.{demo_schema_name}.users_checked"),
+        quarantine_config=OutputConfig(location=f"{demo_catalog_name}.{demo_schema_name}.users_quarantine"),
+        checks=user_checks
+    ),
+    TableCheckConfig(
+        input_config=InputConfig(location=f"{demo_catalog_name}.{demo_schema_name}.orders"),
+        output_config=OutputConfig(location=f"{demo_catalog_name}.{demo_schema_name}.orders_checked"),
+        quarantine_config=OutputConfig(location=f"{demo_catalog_name}.{demo_schema_name}.orders_quarantine"),
+        checks=order_checks
+    )
+]
+
+# Apply checks to multiple tables and save the results
+dq_engine.apply_checks_and_save_in_tables(
+    table_configs=table_configs,
+    max_parallelism=4
+)
+
+display(spark.table(f"{demo_catalog_name}.{demo_schema_name}.users_checked"))
+display(spark.table(f"{demo_catalog_name}.{demo_schema_name}.orders_checked"))
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Checking multiple tables using DQRule Objects
+
+# COMMAND ----------
+
+# Define checks using DQRule objects
+user_rule_checks = [
+    DQRowRule(
+        criticality="error",
+        check_func=check_funcs.is_not_null,
+        column="user_id"
+    ),
+    DQRowRule(
+        criticality="warn",
+        check_func=check_funcs.regex_match,
+        column="email",
+        check_func_kwargs={
+            "pattern": r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$"
+        }
+    )
+]
+
+order_rule_checks = [
+    DQRowRule(
+        criticality="error",
+        check_func=check_funcs.is_not_null,
+        column="order_id"
+    ),
+    DQRowRule(
+        criticality="error",
+        check_func=check_funcs.is_not_less_than,
+        column="total_amount",
+        check_func_kwargs={"min_value": 0}
+    )
+]
+
+# Define the table configurations
+table_configs = [
+    TableCheckConfig(
+        input_config=InputConfig(location=f"{demo_catalog_name}.{demo_schema_name}.users"),
+        output_config=OutputConfig(location=f"{demo_catalog_name}.{demo_schema_name}.users_validated"),
+        quarantine_config=OutputConfig(location=f"{demo_catalog_name}.{demo_schema_name}.users_issues"),
+        checks=user_rule_checks
+    ),
+    TableCheckConfig(
+        input_config=InputConfig(location=f"{demo_catalog_name}.{demo_schema_name}.orders"),
+        output_config=OutputConfig(location=f"{demo_catalog_name}.{demo_schema_name}.orders_validated"),
+        quarantine_config=OutputConfig(location=f"{demo_catalog_name}.{demo_schema_name}.orders_issues"),
+        checks=order_rule_checks
+    )
+]
+
+# Apply checks to multiple tables and save the results
+dq_engine.apply_checks_and_save_in_tables(
+    table_configs=table_configs,
+    max_parallelism=4
+)
+
+display(spark.table(f"{demo_catalog_name}.{demo_schema_name}.users_validated"))
+display(spark.table(f"{demo_catalog_name}.{demo_schema_name}.orders_validated"))
+
+
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC ## Bulk processing of many tables
+
+# COMMAND ----------
+
+# Create sample tables for bulk processing demonstration
+for i in range(1, 6):  # Create 5 sample tables
+    sample_data = [
+        (i, f"Item {i}", "2023-01-01"),
+        (i+10, f"Item {i+10}", "2023-02-01"),
+        (None, f"Item missing", "2023-03-01")  # Missing ID
+    ]
+    
+    sample_df = spark.createDataFrame(
+        sample_data,
+        schema="id int, name string, created_on date"
+    )
+    sample_df.write.mode("overwrite").saveAsTable(f"{demo_catalog_name}.{demo_schema_name}.demo_table_{i}")
+
+# Create a larger set of table configurations for demonstration
+production_tables = [
+    TableCheckConfig(
+        input_config=InputConfig(location=f"{demo_catalog_name}.{demo_schema_name}.demo_table_{i}"),
+        output_config=OutputConfig(location=f"{demo_catalog_name}.{demo_schema_name}.demo_table_{i}_validated"),
+        checks=[
+            {
+                "criticality": "error",
+                "check": {
+                    "function": "is_not_null",
+                    "arguments": {"column": "id"}
+                }
+            },
+            {
+                "criticality": "warn",
+                "check": {
+                    "function": "sql_expression",
+                    "arguments": {
+                        "expression": "created_on <= current_date()",
+                        "msg": "Created on should not be in the future"
+                    }
+                }
+            }
+        ]
+    )
+    for i in range(1, 6)
+]
+
+# Apply checks to multiple tables and save the results
+dq_engine.apply_checks_and_save_in_tables(
+    table_configs=production_tables,
+    max_parallelism=3
+)
+
+display(spark.table(f"{demo_catalog_name}.{demo_schema_name}.demo_table_5_validated"))

--- a/docs/dqx/docs/guide/quality_checks.mdx
+++ b/docs/dqx/docs/guide/quality_checks.mdx
@@ -870,7 +870,7 @@ The `apply_checks_and_save_in_table` method reads data from an input table or se
 
 ### Method 2: Using YAML/JSON Definitions
 
-The `apply_checks_by_metadata_and_save_in_table` method reads data from an input tables or set of files, applies checks loaded from configuration, and writes checked data to output tables.
+The `apply_checks_by_metadata_and_save_in_table` method reads data from an input table or set of files, applies checks loaded from configuration, and writes checked data to output tables.
 
 <Tabs>
   <TabItem value="Python" label="Python" default>

--- a/docs/dqx/docs/guide/quality_checks.mdx
+++ b/docs/dqx/docs/guide/quality_checks.mdx
@@ -870,7 +870,7 @@ The `apply_checks_and_save_in_table` method reads data from an input table or se
 
 ### Method 2: Using YAML/JSON Definitions
 
-The `apply_checks_by_metadata_and_save_in_table` method reads data from an input table or set of files, applies checks loaded from configuration, and writes checked data to output tables.
+The `apply_checks_by_metadata_and_save_in_table` method reads data from an input tables or set of files, applies checks loaded from configuration, and writes checked data to output tables.
 
 <Tabs>
   <TabItem value="Python" label="Python" default>
@@ -912,6 +912,76 @@ The `apply_checks_by_metadata_and_save_in_table` method reads data from an input
         checks=checks,
         input_config=InputConfig("catalog.schema.input_data")
         output_config=OutputConfig("catalog.schema.valid_and_quarantine_data"),
+    )
+    ```
+  </TabItem>
+</Tabs>
+
+### End-to-end Checking for Multiple Tables
+
+Use `apply_checks_and_save_in_tables` to perform end-to-end quality checking for multiple tables. Input sources, checks, and output tables are defined using the `TableCheckConfig`.
+
+<Tabs>
+  <TabItem value="Python" label="Python" default>
+    ```python
+    import yaml
+    from databricks.labs.dqx.config import InputConfig, OutputConfig, TableCheckConfig
+    from databricks.labs.dqx.engine import DQEngine
+    from databricks.sdk import WorkspaceClient
+
+    dq_engine = DQEngine(WorkspaceClient())
+
+    # Define some checks using DQRule classes
+    rule_checks = [
+        DQRowRule(
+            name="id_not_null",
+            criticality="error",
+            check_func=check_funcs.is_not_null,
+            column="id",
+        ),
+        DQRowRule(
+            name="amount_positive",
+            criticality="warn",
+            check_func=check_funcs.is_greater_than,
+            column="amount",
+            limit=0,
+        ),
+    ]
+
+    # Define checks using YAML
+    metadata_checks = yaml.safe_load("""
+    - name: id_is_null
+      criticality: error
+      check:
+        function: is_not_null
+        arguments:
+          column: id
+    - name: email_invalid_format
+      criticality: warn
+      check:
+        function: regex_match
+        arguments:
+          column: email
+          pattern: ^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$
+    """)
+
+    # Define a table configuration to check multiple tables
+    table_configs = [
+      TableCheckConfig(
+        input_config=InputConfig("catalog.schema.input_data_001"),
+        output_config=OutputConfig("catalog.schema.output_data_001"),
+        checks=rule_checks
+      ),
+      TableCheckConfig(
+        input_config=InputConfig("catalog.schema.input_data_002"),
+        output_config=OutputConfig("catalog.schema.output_data_002"),
+        checks=metadata_checks
+      ),
+    ]
+
+    # Check each input table and write data to the corresponding output tables
+    dq_engine.apply_checks_and_save_in_tables(
+        table_configs=table_configs, max_parallelism=2
     )
     ```
   </TabItem>

--- a/docs/dqx/docs/guide/quality_checks.mdx
+++ b/docs/dqx/docs/guide/quality_checks.mdx
@@ -925,7 +925,7 @@ Use `apply_checks_and_save_in_tables` to perform end-to-end quality checking for
   <TabItem value="Python" label="Python" default>
     ```python
     import yaml
-    from databricks.labs.dqx.config import InputConfig, OutputConfig, TableCheckConfig
+    from databricks.labs.dqx.config import ApplyChecksConfig, InputConfig, OutputConfig
     from databricks.labs.dqx.engine import DQEngine
     from databricks.sdk import WorkspaceClient
 
@@ -965,14 +965,14 @@ Use `apply_checks_and_save_in_tables` to perform end-to-end quality checking for
           pattern: ^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$
     """)
 
-    # Define a table configuration to check multiple tables
-    table_configs = [
-      TableCheckConfig(
+    # Define configuration to check multiple tables
+    configs = [
+      ApplyChecksConfig(
         input_config=InputConfig("catalog.schema.input_data_001"),
         output_config=OutputConfig("catalog.schema.output_data_001"),
         checks=rule_checks
       ),
-      TableCheckConfig(
+      ApplyChecksConfig(
         input_config=InputConfig("catalog.schema.input_data_002"),
         output_config=OutputConfig("catalog.schema.output_data_002"),
         checks=metadata_checks
@@ -981,7 +981,7 @@ Use `apply_checks_and_save_in_tables` to perform end-to-end quality checking for
 
     # Check each input table and write data to the corresponding output tables
     dq_engine.apply_checks_and_save_in_tables(
-        table_configs=table_configs, max_parallelism=2
+      configs=configs, max_parallelism=2
     )
     ```
   </TabItem>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -442,7 +442,7 @@ max-locals = 21
 max-parents = 7
 
 # Maximum number of public methods for a class (see R0904).
-max-public-methods = 21
+max-public-methods = 22
 
 # Maximum number of return / yield for function / method body.
 max-returns = 11

--- a/src/databricks/labs/dqx/checks_storage.py
+++ b/src/databricks/labs/dqx/checks_storage.py
@@ -28,7 +28,7 @@ from databricks.labs.dqx.checks_serializer import (
     get_file_deserializer,
 )
 from databricks.labs.dqx.config_loader import RunConfigLoader
-from databricks.labs.dqx.utils import TABLE_PATTERN
+from databricks.labs.dqx.io import TABLE_PATTERN
 from databricks.labs.dqx.checks_serializer import FILE_SERIALIZERS
 
 

--- a/src/databricks/labs/dqx/config.py
+++ b/src/databricks/labs/dqx/config.py
@@ -1,6 +1,9 @@
 import abc
 from dataclasses import dataclass, field
+from typing import Any
+from pyspark.sql import DataFrame
 from databricks.sdk.core import Config
+from databricks.labs.dqx.rule import DQRule
 
 __all__ = [
     "WorkspaceConfig",
@@ -8,6 +11,7 @@ __all__ = [
     "InputConfig",
     "OutputConfig",
     "ProfilerConfig",
+    "ApplyChecksConfig",
     "BaseChecksStorageConfig",
     "FileChecksStorageConfig",
     "WorkspaceFileChecksStorageConfig",
@@ -47,6 +51,18 @@ class ProfilerConfig:
     sample_fraction: float = 0.3  # fraction of data to sample (30%)
     sample_seed: int | None = None  # seed for sampling
     limit: int = 1000  # limit the number of records to profile
+
+
+@dataclass
+class ApplyChecksConfig:
+    """Configuration class for applying checks to a table."""
+
+    input_config: InputConfig
+    output_config: OutputConfig
+    quarantine_config: OutputConfig | None = None
+    checks: list[dict] | list[DQRule] | None = None  # DQRule objects or dict representations
+    custom_check_functions: dict[str, Any] | None = None
+    ref_dfs: dict[str, DataFrame] | None = None  # Reference DataFrames for the checks
 
 
 @dataclass

--- a/src/databricks/labs/dqx/engine.py
+++ b/src/databricks/labs/dqx/engine.py
@@ -428,7 +428,7 @@ class DQEngine(DQEngineBase):
 
     def apply_checks_and_save_in_tables(
         self,
-        table_configs: list[ApplyChecksConfig],
+        configs: list[ApplyChecksConfig],
         max_parallelism: int | None = os.cpu_count(),
     ) -> None:
         """
@@ -439,13 +439,13 @@ class DQEngine(DQEngineBase):
         quarantine table. If quarantine tables are not provided, all records (with error/warning
         columns) will be written to the output table.
 
-        :param table_configs: List of table check configurations, each containing input, output, quarantine configs,
+        :param configs: List of apply check configurations, each containing input, output, quarantine configs,
                              and checks to apply.
         :param max_parallelism: Maximum number of tables to check in parallel.
         """
-        logger.info(f"Applying checks to {len(table_configs)} tables with {max_parallelism} parallelism")
+        logger.info(f"Applying checks to {len(configs)} tables with {max_parallelism} parallelism")
         with futures.ThreadPoolExecutor(max_workers=max_parallelism) as executor:
-            executor.map(lambda config: self._get_apply_checks_method(config)(**asdict(config)), table_configs)
+            executor.map(lambda config: self._get_apply_checks_method(config)(**asdict(config)), configs)
 
     @staticmethod
     def validate_checks(

--- a/src/databricks/labs/dqx/io.py
+++ b/src/databricks/labs/dqx/io.py
@@ -1,0 +1,105 @@
+import logging
+import re
+
+from typing import Any
+from pyspark.sql import SparkSession
+from pyspark.sql.dataframe import DataFrame
+from databricks.labs.dqx.config import InputConfig, OutputConfig
+
+logger = logging.getLogger(__name__)
+
+STORAGE_PATH_PATTERN = re.compile(r"^(/|s3:/|abfss:/|gs:/)")
+# catalog.schema.table or schema.table or database.table
+TABLE_PATTERN = re.compile(r"^(?:[a-zA-Z0-9_]+\.)?[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$")
+
+
+def read_input_data(
+    spark: SparkSession,
+    input_config: InputConfig,
+) -> DataFrame:
+    """
+    Reads input data from the specified location and format.
+
+    :param spark: SparkSession
+    :param input_config: InputConfig with source location/table name, format, and options
+    :return: DataFrame with values read from the input data
+    """
+    if not input_config.location:
+        raise ValueError("Input location not configured")
+
+    if TABLE_PATTERN.match(input_config.location):
+        return _read_table_data(spark, input_config)
+
+    if STORAGE_PATH_PATTERN.match(input_config.location):
+        return _read_file_data(spark, input_config)
+
+    raise ValueError(
+        f"Invalid input location. It must be a 2 or 3-level table namespace or storage path, given {input_config.location}"
+    )
+
+
+def _read_file_data(spark: SparkSession, input_config: InputConfig) -> DataFrame:
+    """
+    Reads input data from files (e.g. JSON). Streaming reads must use auto loader with a 'cloudFiles' format.
+    :param spark: SparkSession
+    :param input_config: InputConfig with source location, format, and options
+    :return: DataFrame with values read from the file data
+    """
+    if not input_config.is_streaming:
+        return spark.read.options(**input_config.options).load(
+            input_config.location, format=input_config.format, schema=input_config.schema
+        )
+
+    if input_config.format != "cloudFiles":
+        raise ValueError("Streaming reads from file sources must use 'cloudFiles' format")
+
+    return spark.readStream.options(**input_config.options).load(
+        input_config.location, format=input_config.format, schema=input_config.schema
+    )
+
+
+def _read_table_data(spark: SparkSession, input_config: InputConfig) -> DataFrame:
+    """
+    Reads input data from a table registered in Unity Catalog.
+    :param spark: SparkSession
+    :param input_config: InputConfig with source location, format, and options
+    :return: DataFrame with values read from the table data
+    """
+    if not input_config.is_streaming:
+        return spark.read.options(**input_config.options).table(input_config.location)
+    return spark.readStream.options(**input_config.options).table(input_config.location)
+
+
+def save_dataframe_as_table(df: DataFrame, output_config: OutputConfig):
+    """
+    Helper method to save a DataFrame to a Delta table.
+    :param df: The DataFrame to save
+    :param output_config: Output table name, write mode, and options
+    """
+    logger.info(f"Saving data to {output_config.location} table")
+
+    if df.isStreaming:
+        if not output_config.trigger:
+            query = (
+                df.writeStream.format(output_config.format)
+                .outputMode(output_config.mode)
+                .options(**output_config.options)
+                .toTable(output_config.location)
+            )
+        else:
+            trigger: dict[str, Any] = output_config.trigger
+            query = (
+                df.writeStream.format(output_config.format)
+                .outputMode(output_config.mode)
+                .options(**output_config.options)
+                .trigger(**trigger)
+                .toTable(output_config.location)
+            )
+        query.awaitTermination()
+    else:
+        (
+            df.write.format(output_config.format)
+            .mode(output_config.mode)
+            .options(**output_config.options)
+            .saveAsTable(output_config.location)
+        )

--- a/src/databricks/labs/dqx/profiler/profiler.py
+++ b/src/databricks/labs/dqx/profiler/profiler.py
@@ -18,7 +18,7 @@ from pyspark.sql import DataFrame
 from databricks.labs.blueprint.limiter import rate_limited
 from databricks.labs.dqx.base import DQEngineBase
 from databricks.labs.dqx.config import InputConfig
-from databricks.labs.dqx.utils import read_input_data
+from databricks.labs.dqx.io import read_input_data
 
 logger = logging.getLogger(__name__)
 

--- a/src/databricks/labs/dqx/profiler/runner.py
+++ b/src/databricks/labs/dqx/profiler/runner.py
@@ -4,7 +4,7 @@ import yaml
 from pyspark.sql import SparkSession
 
 from databricks.labs.dqx.config import InputConfig, ProfilerConfig
-from databricks.labs.dqx.utils import read_input_data
+from databricks.labs.dqx.io import read_input_data
 from databricks.labs.dqx.profiler.generator import DQGenerator
 from databricks.labs.dqx.profiler.profiler import DQProfiler
 from databricks.sdk import WorkspaceClient

--- a/src/databricks/labs/dqx/utils.py
+++ b/src/databricks/labs/dqx/utils.py
@@ -4,17 +4,12 @@ import re
 from typing import Any
 import datetime
 
-from pyspark.sql import Column, SparkSession
-from pyspark.sql.dataframe import DataFrame
+from pyspark.sql import Column
 from pyspark.sql.connect.column import Column as ConnectColumn
-from databricks.labs.dqx.config import InputConfig, OutputConfig
 
 logger = logging.getLogger(__name__)
 
 
-STORAGE_PATH_PATTERN = re.compile(r"^(/|s3:/|abfss:/|gs:/)")
-# catalog.schema.table or schema.table or database.table
-TABLE_PATTERN = re.compile(r"^(?:[a-zA-Z0-9_]+\.)?[a-zA-Z0-9_]+\.[a-zA-Z0-9_]+$")
 COLUMN_NORMALIZE_EXPRESSION = re.compile("[^a-zA-Z0-9]+")
 COLUMN_PATTERN = re.compile(r"Column<'(.*?)(?: AS (\w+))?'>$")
 INVALID_COLUMN_NAME_PATTERN = re.compile(r"[\s,;{}\(\)\n\t=]+")
@@ -137,98 +132,6 @@ def normalize_col_str(col_str: str) -> str:
     """
     max_chars = 255
     return re.sub(COLUMN_NORMALIZE_EXPRESSION, "_", col_str[:max_chars].lower()).rstrip("_")
-
-
-def read_input_data(
-    spark: SparkSession,
-    input_config: InputConfig,
-) -> DataFrame:
-    """
-    Reads input data from the specified location and format.
-
-    :param spark: SparkSession
-    :param input_config: InputConfig with source location/table name, format, and options
-    :return: DataFrame with values read from the input data
-    """
-    if not input_config.location:
-        raise ValueError("Input location not configured")
-
-    if TABLE_PATTERN.match(input_config.location):
-        return _read_table_data(spark, input_config)
-
-    if STORAGE_PATH_PATTERN.match(input_config.location):
-        return _read_file_data(spark, input_config)
-
-    raise ValueError(
-        f"Invalid input location. It must be a 2 or 3-level table namespace or storage path, given {input_config.location}"
-    )
-
-
-def _read_file_data(spark: SparkSession, input_config: InputConfig) -> DataFrame:
-    """
-    Reads input data from files (e.g. JSON). Streaming reads must use auto loader with a 'cloudFiles' format.
-    :param spark: SparkSession
-    :param input_config: InputConfig with source location, format, and options
-    :return: DataFrame with values read from the file data
-    """
-    if not input_config.is_streaming:
-        return spark.read.options(**input_config.options).load(
-            input_config.location, format=input_config.format, schema=input_config.schema
-        )
-
-    if input_config.format != "cloudFiles":
-        raise ValueError("Streaming reads from file sources must use 'cloudFiles' format")
-
-    return spark.readStream.options(**input_config.options).load(
-        input_config.location, format=input_config.format, schema=input_config.schema
-    )
-
-
-def _read_table_data(spark: SparkSession, input_config: InputConfig) -> DataFrame:
-    """
-    Reads input data from a table registered in Unity Catalog.
-    :param spark: SparkSession
-    :param input_config: InputConfig with source location, format, and options
-    :return: DataFrame with values read from the table data
-    """
-    if not input_config.is_streaming:
-        return spark.read.options(**input_config.options).table(input_config.location)
-    return spark.readStream.options(**input_config.options).table(input_config.location)
-
-
-def save_dataframe_as_table(df: DataFrame, output_config: OutputConfig):
-    """
-    Helper method to save a DataFrame to a Delta table.
-    :param df: The DataFrame to save
-    :param output_config: Output table name, write mode, and options
-    """
-    logger.info(f"Saving data to {output_config.location} table")
-
-    if df.isStreaming:
-        if not output_config.trigger:
-            query = (
-                df.writeStream.format(output_config.format)
-                .outputMode(output_config.mode)
-                .options(**output_config.options)
-                .toTable(output_config.location)
-            )
-        else:
-            trigger: dict[str, Any] = output_config.trigger
-            query = (
-                df.writeStream.format(output_config.format)
-                .outputMode(output_config.mode)
-                .options(**output_config.options)
-                .trigger(**trigger)
-                .toTable(output_config.location)
-            )
-        query.awaitTermination()
-    else:
-        (
-            df.write.format(output_config.format)
-            .mode(output_config.mode)
-            .options(**output_config.options)
-            .saveAsTable(output_config.location)
-        )
 
 
 def is_sql_query_safe(query: str) -> bool:

--- a/tests/e2e/test_run_demos.py
+++ b/tests/e2e/test_run_demos.py
@@ -231,6 +231,26 @@ def test_run_dqx_streaming_demo_diy(make_notebook, make_job, tmp_path, library_r
     logging.info(f"Job run {run.run_id} completed successfully for dqx_streaming_demo")
 
 
+def test_run_dqx_multi_table_demo(make_notebook, make_job, library_ref):
+
+    ws = WorkspaceClient()
+    path = Path(__file__).parent.parent.parent / "demos" / "dqx_multi_table_demo.py"
+    with open(path, "rb") as f:
+        notebook = make_notebook(content=f, format=ImportFormat.SOURCE)
+
+    notebook_path = notebook.as_fuse().as_posix()
+    notebook_task = NotebookTask(notebook_path=notebook_path, base_parameters={"test_library_ref": library_ref})
+    job = make_job(tasks=[Task(task_key="dqx_multi_table_demo", notebook_task=notebook_task)])
+
+    waiter = ws.jobs.run_now_and_wait(job.job_id)
+    run = ws.jobs.wait_get_run_job_terminated_or_skipped(
+        run_id=waiter.run_id,
+        timeout=timedelta(minutes=30),
+        callback=lambda r: validate_run_status(r, ws),
+    )
+    logging.info(f"Job run {run.run_id} completed successfully for dqx_multi_table_demo")
+
+
 def validate_run_status(run: Run, client: WorkspaceClient) -> None:
     """
     Validates that a job task run completed successfully.

--- a/tests/integration/test_save_results_in_table.py
+++ b/tests/integration/test_save_results_in_table.py
@@ -938,7 +938,7 @@ def test_apply_checks_and_save_in_tables_single_table(ws, spark, make_schema, ma
     ]
 
     # Configure table checks
-    table_configs = [
+    configs = [
         ApplyChecksConfig(
             input_config=InputConfig(location=input_table),
             output_config=OutputConfig(location=output_table, mode="overwrite"),
@@ -948,7 +948,7 @@ def test_apply_checks_and_save_in_tables_single_table(ws, spark, make_schema, ma
 
     # Apply checks and write to table
     engine = DQEngine(ws, spark=spark, extra_params=EXTRA_PARAMS)
-    engine.apply_checks_and_save_in_tables(table_configs=table_configs, max_parallelism=1)
+    engine.apply_checks_and_save_in_tables(configs=configs, max_parallelism=1)
 
     # Verify the table was created and contains the expected data
     actual_df = spark.table(output_table)
@@ -1036,7 +1036,7 @@ def test_apply_checks_and_save_in_tables_multiple_tables(ws, spark, make_schema,
     }
 
     # Configure multiple table checks
-    table_configs = [
+    configs = [
         ApplyChecksConfig(
             input_config=InputConfig(location=input_table1),
             output_config=OutputConfig(location=output_table1, mode="overwrite"),
@@ -1051,7 +1051,7 @@ def test_apply_checks_and_save_in_tables_multiple_tables(ws, spark, make_schema,
 
     # Apply checks and write to tables
     engine = DQEngine(ws, spark=spark, extra_params=EXTRA_PARAMS)
-    engine.apply_checks_and_save_in_tables(table_configs=table_configs, max_parallelism=2)
+    engine.apply_checks_and_save_in_tables(configs=configs, max_parallelism=2)
 
     # Verify both tables were created and contain the expected data
     actual_df1 = spark.table(output_table1)
@@ -1136,7 +1136,7 @@ def test_apply_checks_and_save_in_tables_with_quarantine(ws, spark, make_schema,
     ]
 
     # Configure mixed table setups (one with quarantine, one without)
-    table_configs = [
+    configs = [
         ApplyChecksConfig(
             input_config=InputConfig(location=input_tables[0]),
             output_config=OutputConfig(location=output_tables[0], mode="overwrite"),
@@ -1153,7 +1153,7 @@ def test_apply_checks_and_save_in_tables_with_quarantine(ws, spark, make_schema,
 
     # Apply checks and write to tables
     engine = DQEngine(ws, spark=spark, extra_params=EXTRA_PARAMS)
-    engine.apply_checks_and_save_in_tables(table_configs=table_configs, max_parallelism=2)
+    engine.apply_checks_and_save_in_tables(configs=configs, max_parallelism=2)
 
     # Verify first table was split correctly
     actual_validated_df1 = spark.table(output_tables[0])
@@ -1218,7 +1218,7 @@ def test_apply_checks_and_save_in_tables_metadata_checks(ws, spark, make_schema,
     ]
 
     # Configure table checks
-    table_configs = [
+    configs = [
         ApplyChecksConfig(
             input_config=InputConfig(location=input_table),
             output_config=OutputConfig(location=output_table, mode="overwrite"),
@@ -1228,7 +1228,7 @@ def test_apply_checks_and_save_in_tables_metadata_checks(ws, spark, make_schema,
 
     # Apply checks and write to table
     engine = DQEngine(ws, spark=spark, extra_params=EXTRA_PARAMS)
-    engine.apply_checks_and_save_in_tables(table_configs=table_configs, max_parallelism=1)
+    engine.apply_checks_and_save_in_tables(configs=configs, max_parallelism=1)
 
     # Verify the table was created and contains the expected data
     actual_df = spark.table(output_table)
@@ -1295,7 +1295,7 @@ def test_apply_checks_and_save_in_tables_mixed_check_types(ws, spark, make_schem
     ]
 
     # Configure table checks with different check types
-    table_configs = [
+    configs = [
         ApplyChecksConfig(
             input_config=InputConfig(location=input_table1),
             output_config=OutputConfig(location=output_table1, mode="overwrite"),
@@ -1310,7 +1310,7 @@ def test_apply_checks_and_save_in_tables_mixed_check_types(ws, spark, make_schem
 
     # Apply checks and write to tables
     engine = DQEngine(ws, spark=spark, extra_params=EXTRA_PARAMS)
-    engine.apply_checks_and_save_in_tables(table_configs=table_configs, max_parallelism=2)
+    engine.apply_checks_and_save_in_tables(configs=configs, max_parallelism=2)
 
     # Verify both tables produce the same results
     actual_df1 = spark.table(output_table1)
@@ -1350,7 +1350,7 @@ def test_apply_checks_and_save_in_tables_custom_parallelism(ws, spark, make_sche
     schema = make_schema(catalog_name=catalog_name)
 
     # Create 4 tables to test parallelism
-    table_configs = []
+    configs = []
     input_tables = []
     output_tables = []
 
@@ -1377,7 +1377,7 @@ def test_apply_checks_and_save_in_tables_custom_parallelism(ws, spark, make_sche
             ),
         ]
 
-        table_configs.append(
+        configs.append(
             ApplyChecksConfig(
                 input_config=InputConfig(location=input_table),
                 output_config=OutputConfig(location=output_table, mode="overwrite"),
@@ -1387,7 +1387,7 @@ def test_apply_checks_and_save_in_tables_custom_parallelism(ws, spark, make_sche
 
     # Apply checks with limited parallelism
     engine = DQEngine(ws, spark=spark, extra_params=EXTRA_PARAMS)
-    engine.apply_checks_and_save_in_tables(table_configs=table_configs, max_parallelism=2)
+    engine.apply_checks_and_save_in_tables(configs=configs, max_parallelism=2)
 
     # Verify all tables were processed correctly
     for i, output_table in enumerate(output_tables):
@@ -1404,13 +1404,13 @@ def test_apply_checks_and_save_in_tables_custom_parallelism(ws, spark, make_sche
         assert_df_equality(actual_df, expected_df, ignore_nullable=True)
 
 
-def test_apply_checks_and_save_in_tables_empty_table_configs(ws, spark, make_schema, make_random):
+def test_apply_checks_and_save_in_tables_empty_configs(ws, spark, make_schema, make_random):
     """Test apply_checks_and_save_in_tables method with empty table configurations."""
     # Test with empty list of table configs
     engine = DQEngine(ws, spark=spark, extra_params=EXTRA_PARAMS)
 
     # This should not raise an error
-    engine.apply_checks_and_save_in_tables(table_configs=[], max_parallelism=1)
+    engine.apply_checks_and_save_in_tables(configs=[], max_parallelism=1)
 
 
 def test_apply_checks_and_save_in_tables_with_custom_functions(ws, spark, make_schema, make_random):
@@ -1440,7 +1440,7 @@ def test_apply_checks_and_save_in_tables_with_custom_functions(ws, spark, make_s
     ]
 
     # Configure table checks
-    table_configs = [
+    configs = [
         ApplyChecksConfig(
             input_config=InputConfig(location=input_table),
             output_config=OutputConfig(location=output_table, mode="overwrite"),
@@ -1451,7 +1451,7 @@ def test_apply_checks_and_save_in_tables_with_custom_functions(ws, spark, make_s
 
     # Apply checks and write to table
     engine = DQEngine(ws, spark=spark, extra_params=EXTRA_PARAMS)
-    engine.apply_checks_and_save_in_tables(table_configs=table_configs, max_parallelism=1)
+    engine.apply_checks_and_save_in_tables(configs=configs, max_parallelism=1)
 
     # Verify the table was created
     actual_df = spark.table(output_table)

--- a/tests/integration/test_utils.py
+++ b/tests/integration/test_utils.py
@@ -1,7 +1,7 @@
 import pytest
 from chispa.dataframe_comparer import assert_df_equality  # type: ignore
 from databricks.labs.dqx.config import InputConfig, OutputConfig
-from databricks.labs.dqx.utils import read_input_data, save_dataframe_as_table
+from databricks.labs.dqx.io import read_input_data, save_dataframe_as_table
 
 
 def test_read_input_data_no_input_format(spark, make_schema, make_volume):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -5,8 +5,8 @@ import pyspark.sql.functions as F
 import pytest
 from pyspark.sql import Column
 
+from databricks.labs.dqx.io import read_input_data
 from databricks.labs.dqx.utils import (
-    read_input_data,
     get_column_name_or_alias,
     is_sql_query_safe,
     normalize_col_str,


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary -->
This PR adds the `apply_checks_and_save_in_tables` method to support end-to-end checking for multiple input sources (tables or files). This is an extension of #364 .

Users create an `ApplyChecksConfig` with details about the input and output data and the checks to run.

```
config = ApplyChecksConfig(
  input_config = InputConfig("main.demo.input_table"),
  output_config = OutputConfig("main.demo.valid_table"),
  quarantine_config = OutputConfig("main.demo.quarantine_table"),
  checks = {...}
)
```

Multiple `ApplyChecksConfig` objects can then be passed as a list to `apply_checks_and_save_in_tables` to check each source table or file set. 

```
engine = DQEngine(WorkspaceClient())
engine.apply_checks_and_save_in_tables(configs)
```

The parallelism can be tuned by setting `max_parallelism`:

```
engine.apply_checks_and_save_in_tables(configs, max_parallelism = 3)
```

#### To-Do:
- [ ] Add methods to run for an entire catalog or schema
- [ ] Add support for wildcard patterns

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #488 

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [ ] added unit tests
- [x] added integration tests
- [x] added end-to-end tests
