### PR TITLE
Declare readme in the project

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [project]
 name = "databricks-labs-dqx"
-dynamic = ["version", "readme"]
+dynamic = ["version"]
+readme = { file = "README.md", content-type = "text/markdown" }
 description = 'Data Quality eXtended (DQX) is a Python library for data quality checks and data quality monitoring'
 license-files = { paths = ["LICENSE", "NOTICE"] }
 requires-python = ">=3.10"


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary -->

* Including readme in the distribution to have it display correctly in PyPi. It is currently showing: `The author of this package has not provided a project description`

We used to generate readme dynamically, but it was removed 2 releases ago. We haven't change the readme declaration after this change.

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested - `hatch build` and checking the package info includes description
- [ ] added unit tests
- [ ] added integration tests
- [ ] added end-to-end tests
