### PR TITLE
Allow installation in a custom folder

### DIFF
--- a/docs/dqx/docs/installation.mdx
+++ b/docs/dqx/docs/installation.mdx
@@ -98,18 +98,29 @@ It is recommended to use serverless clusters for the workflows, as it allows for
 If serverless clusters are not used, a default cluster configuration will be used for the workflows.
 Alternatively, you can override the cluster configuration for each workflow in the `config.yml` file after the installation, to provide existing clusters to use.
 
-#### User vs Global Installation
+#### Installation Options
 
-DQX is installed by default in the user home directory (under `/Users/<user>/.dqx`). You can also install DQX globally
-by setting the 'DQX_FORCE_INSTALL' environment variable. The following options are available:
+DQX offers flexible installation options. By default, DQX is installed in the user home directory (under `/Users/<user>/.dqx`).
 
-* `DQX_FORCE_INSTALL=global databricks labs install dqx`: will force the installation to be for root only (`/Applications/dqx`)
-* `DQX_FORCE_INSTALL=user databricks labs install dqx`: will force the installation to be for user only (`/Users/<user>/.dqx`)
+**Custom Workspace Folder:**
+If you provide a custom path during installation (e.g., `/Shared/dqx-team` or `/Users/shared-user/dqx-project`), DQX will be installed there.
+
+**Environment Variable Override:**
+You can also force global or user installation using the 'DQX_FORCE_INSTALL' environment variable:
+  * `DQX_FORCE_INSTALL=global databricks labs install dqx`: forces installation to `/Applications/dqx`
+  * `DQX_FORCE_INSTALL=user databricks labs install dqx`: forces installation to `/Users/<user>/.dqx`
+
+<Admonition type="info" title="Complete Profiling Guide">
+If a custom folder is provided during installation, the installation folder will take precedence over any environment variables (e.g. `DQX_FORCE_INSTALL`).
+</Admonition> 
 
 #### Configuration file
 
 DQX configuration file can contain multiple run configurations for different pipelines or projects, each defining specific input, output and quarantine locations, etc.
-By default, the config is created in the installation directory under `/Users/<user>/.dqx/config.yml` or `/Applications/dqx/config.yml` if installed globally.
+The configuration file is created in the installation directory:
+- Custom folder: `<your-installation-folder>/config.yml`
+- User home (default): `/Users/<user>/.dqx/config.yml`
+- Global: `/Applications/dqx/config.yml`
 The "default" run configuration is created during the installation. When DQX is upgraded, the configuration is preserved.
 The configuration can be updated / extended manually by the user after the installation. Each run config defines configuration for one specific input and output location.
 

--- a/docs/dqx/docs/reference/cli.mdx
+++ b/docs/dqx/docs/reference/cli.mdx
@@ -24,8 +24,9 @@ databricks labs uninstall dqx
 ```
 
 <Admonition type="info" title="Where is DQX installed?">
-By default, DQX is installed under the user's home (for example `/Users/<user>/.dqx`).
-Use the `DQX_FORCE_INSTALL` env var to force a global or user install. See the installation guide for details.
+By default, DQX is installed under the user's home folder (for example `/Users/<user>/.dqx`).
+Use the `DQX_FORCE_INSTALL` env var to force a global or user install. Provide a custom installation
+folder during installation to override the default location. See the installation guide for details.
 </Admonition>
 
 ## Configuration helpers

--- a/src/databricks/labs/dqx/base.py
+++ b/src/databricks/labs/dqx/base.py
@@ -45,7 +45,7 @@ class DQEngineBase(abc.ABC):
             setattr(ws.config, '_product_info', ('dqx', __version__))
 
         # make sure Databricks workspace is accessible
-        ws.current_user.me()
+        ws.get_workspace_id()
         return ws
 
 

--- a/src/databricks/labs/dqx/checks_storage.py
+++ b/src/databricks/labs/dqx/checks_storage.py
@@ -254,9 +254,11 @@ class InstallationChecksStorageHandler(ChecksStorageHandler[InstallationChecksSt
         self, config: InstallationChecksStorageConfig
     ) -> tuple[ChecksStorageHandler, InstallationChecksStorageConfig]:
         run_config = self._run_config_loader.load_run_config(
-            config.run_config_name, config.assume_user, config.product_name
+            run_config_name=config.run_config_name, assume_user=config.assume_user, product_name=config.product_name
         )
-        installation = self._run_config_loader.get_installation(config.assume_user, config.product_name)
+        installation = self._run_config_loader.get_installation(
+            config.assume_user, config.product_name, config.install_folder
+        )
 
         config.location = run_config.checks_location
 

--- a/src/databricks/labs/dqx/config.py
+++ b/src/databricks/labs/dqx/config.py
@@ -219,9 +219,11 @@ class InstallationChecksStorageConfig(
         run_config_name: The name of the run configuration to use for checks (default is 'default').
         product_name: The product name for retrieving checks from the installation (default is 'dqx').
         assume_user: Whether to assume the user is the owner of the checks (default is True).
+        install_folder: The installation folder where DQX is installed
     """
 
     location: str = "installation"  # retrieved from the installation config
     run_config_name: str = "default"  # to retrieve run config
     product_name: str = "dqx"
     assume_user: bool = True
+    install_folder: str | None = None

--- a/src/databricks/labs/dqx/config_loader.py
+++ b/src/databricks/labs/dqx/config_loader.py
@@ -13,28 +13,38 @@ class RunConfigLoader:
         self.ws = workspace_client
 
     def load_run_config(
-        self, run_config_name: str | None, assume_user: bool = True, product_name: str = "dqx"
+        self,
+        run_config_name: str | None,
+        install_folder: str | None = None,
+        assume_user: bool = True,
+        product_name: str = "dqx",
     ) -> RunConfig:
         """
         Load run configuration from the installation.
 
         Args:
             run_config_name: name of the run configuration to use
+            install_folder: optional installation folder
             assume_user: if True, assume user installation
             product_name: name of the product
         """
-        installation = self.get_installation(assume_user, product_name)
+        installation = self.get_installation(assume_user, product_name, install_folder)
         return self._load_run_config(installation, run_config_name)
 
-    def get_installation(self, assume_user: bool, product_name: str) -> Installation:
+    def get_installation(self, assume_user: bool, product_name: str, install_folder: str | None = None) -> Installation:
         """
         Get the installation for the given product name.
 
         Args:
             assume_user: if True, assume user installation
             product_name: name of the product
+            install_folder: optional installation folder
         """
-        if assume_user:
+
+        if install_folder:
+            installation = Installation(self.ws, product_name, install_folder=install_folder)
+            assume_user = False
+        elif assume_user:
             installation = Installation.assume_user_home(self.ws, product_name)
         else:
             installation = Installation.assume_global(self.ws, product_name)

--- a/src/databricks/labs/dqx/engine.py
+++ b/src/databricks/labs/dqx/engine.py
@@ -620,11 +620,15 @@ class DQEngine(DQEngineBase):
             None
         """
         if output_df is not None and output_config is None:
-            run_config = self._run_config_loader.load_run_config(run_config_name, assume_user, product_name)
+            run_config = self._run_config_loader.load_run_config(
+                run_config_name=run_config_name, assume_user=assume_user, product_name=product_name
+            )
             output_config = run_config.output_config
 
         if quarantine_df is not None and quarantine_config is None:
-            run_config = self._run_config_loader.load_run_config(run_config_name, assume_user, product_name)
+            run_config = self._run_config_loader.load_run_config(
+                run_config_name=run_config_name, assume_user=assume_user, product_name=product_name
+            )
             quarantine_config = run_config.quarantine_config
 
         if output_df is not None and output_config is not None:

--- a/src/databricks/labs/dqx/installer/config_provider.py
+++ b/src/databricks/labs/dqx/installer/config_provider.py
@@ -17,11 +17,17 @@ class ConfigProvider:
         self._prompts = prompts
         self._warehouse_configurator = warehouse_configurator
 
-    def prompt_new_installation(self) -> WorkspaceConfig:
+    def prompt_new_installation(self, install_folder: str | None = None) -> WorkspaceConfig:
         logger.info(
             "Please answer a couple of questions to provide default DQX run configuration. "
             "The configuration can also be updated manually after the installation."
         )
+
+        # Show installation folder information
+        if install_folder:
+            logger.info(f"DQX will be installed in folder '{install_folder}'")
+        else:
+            logger.info("DQX will be installed in the default location (user home or global based on environment)")
 
         log_level = self._prompts.question("Log level", default="INFO").upper()
         is_streaming = self._prompts.confirm("Should the input data be read using streaming?")

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -352,6 +352,35 @@ def test_workflows_deployment_creates_jobs_with_remove_after_tag():
     wheels.assert_not_called()
 
 
+def test_custom_folder_installation(ws, new_installation, make_random):
+    product_info = ProductInfo.for_testing(WorkspaceConfig)
+    custom_folder = f"/Shared/dqx-test-{make_random}"
+
+    custom_installation = Installation(ws, product_info.product_name(), install_folder=custom_folder)
+    installation = new_installation(
+        product_info=product_info,
+        installation=custom_installation,
+    )
+
+    assert installation.install_folder() == custom_folder
+    assert ws.workspace.get_status(custom_folder)
+
+
+def test_custom_folder_installation_with_environment_variable(ws, new_installation, make_random):
+    product_info = ProductInfo.for_testing(WorkspaceConfig)
+    custom_folder = f"/Shared/dqx-test-{make_random}"
+
+    custom_installation = Installation(ws, product_info.product_name(), install_folder=custom_folder)
+    installation = new_installation(
+        product_info=product_info,
+        installation=custom_installation,
+        environ={'DQX_FORCE_INSTALL': 'global'},  # environment variable should not override the install folder
+    )
+
+    assert installation.install_folder() == custom_folder
+    assert ws.workspace.get_status(custom_folder)
+
+
 def test_my_username():
     """Test the _my_username property to cover both conditions."""
 


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary -->
This PR introduces a new installation prompt which asks users to provide a workspace path when installing DQX as a tool.

I've also refactored the engine to use `WorkspaceClient().get_workspace_id()` instead of `WorkspaceClient().current_user.me()` to support running checks on group-assigned clusters.

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #538 #545

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [ ] added unit tests
- [x] added integration tests
- [ ] added end-to-end tests
- [ ] added performance tests
