### PR TITLE
Restore use of `hatch-fancy-pypi-readme` to fix images in PyPi

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ DQX by Databricks Labs
 
 <p align="center">
     <a href="https://github.com/databrickslabs/dqx">
-        <img src="./docs/dqx/static/img/logo.svg" class="align-center" width="200" height="200" alt="logo" />
+        <img src="docs/dqx/static/img/logo.svg" class="align-center" width="200" height="200" alt="logo" />
     </a>
 </p>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ keywords = ["Databricks"]
 maintainers = [
     { name = "Databricks Labs", email = "labs-oss@databricks.com" },
     { name = "Marcin Wojtyczka", email = "marcin.wojtyczka@databricks.com" },
-    { name = "Alex Ott", email = "alex.ott@databricks.com" },
+    { name = "Alex Ott", email = "alexey.ott@databricks.com" },
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -63,7 +63,9 @@ Issues = "https://github.com/databrickslabs/dqx/issues"
 Source = "https://github.com/databrickslabs/dqx"
 
 [build-system]
-requires = ["hatchling>=1.9.0"]
+# The `hatch-fancy-pypi-readme` plugin is used to generate correct links
+# in README showed on PyPi
+requires = ["hatchling>=1.9.0", "hatch-fancy-pypi-readme"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build]
@@ -807,3 +809,23 @@ ignored-argument-names = "_.*|^ignored_|^unused_"
 # List of qualified module names which can have objects that can redefine
 # builtins.
 redefining-builtins-modules = ["six.moves", "past.builtins", "future.builtins", "builtins", "io"]
+
+# This plugin is used to generate correct links in README showed on PyPi
+[tool.hatch.metadata.hooks.fancy-pypi-readme]
+content-type = "text/markdown"
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+path = "README.md"
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+# replace relative links with absolute links
+pattern = '\[(.+?)\]\(((?!https?://)\S+?)\)'
+replacement = '[\1](https://github.com/databrickslabs/dqx/tree/main/\g<2>)'
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+# replace relative image links with absolute links
+pattern = '<img (.*?)src="((?!https?://)\S+?)"(.*?)>'
+replacement = '<img \1src="https://raw.githubusercontent.com/databrickslabs/dqx/refs/heads/main/\g<2>"\g<3>>'
+
+# custom hooks defined in hatch_build.py
+[tool.hatch.build.hooks.custom]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -826,6 +826,3 @@ replacement = '[\1](https://github.com/databrickslabs/dqx/tree/main/\g<2>)'
 # replace relative image links with absolute links
 pattern = '<img (.*?)src="((?!https?://)\S+?)"(.*?)>'
 replacement = '<img \1src="https://raw.githubusercontent.com/databrickslabs/dqx/refs/heads/main/\g<2>"\g<3>>'
-
-# custom hooks defined in hatch_build.py
-[tool.hatch.build.hooks.custom]


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary -->

We need the `hatch-fancy-pypi-readme` plugin to generate correct links in README when generating a release.

Resolves #600


### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #..

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] added end-to-end tests
- [ ] added performance tests
