### PR TITLE
default product_info when None in config while verifying workspaceClient

### DIFF
--- a/src/databricks/labs/dqx/base.py
+++ b/src/databricks/labs/dqx/base.py
@@ -29,8 +29,8 @@ class DQEngineBase(abc.ABC):
         Verify the Databricks WorkspaceClient configuration and connectivity.
         """
         # Using reflection to set right value for _product_info as dqx for telemetry
-        product_info = getattr(ws.config, '_product_info')
-        if product_info[0] != "dqx":
+        product_info = getattr(ws.config, '_product_info', None)
+        if product_info is None or product_info[0] != "dqx":
             setattr(ws.config, '_product_info', ('dqx', __version__))
 
         # make sure Databricks workspace is accessible

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -1,10 +1,11 @@
 from datetime import datetime, timezone
-from unittest.mock import create_autospec
+from unittest.mock import create_autospec, Mock
 import pytest
 from pyspark.sql import SparkSession
 from databricks.sdk.errors import DatabricksError
 from databricks.sdk import WorkspaceClient
 
+from databricks.labs.dqx.__about__ import __version__
 from databricks.labs.dqx.config import ExtraParams
 from databricks.labs.dqx.engine import DQEngine, DQEngineCore
 from databricks.labs.dqx.metrics_observer import DQMetricsObserver
@@ -72,3 +73,25 @@ def test_get_streaming_metrics_listener_no_observer(mock_workspace_client, mock_
     engine = DQEngine(mock_workspace_client, mock_spark)
     with pytest.raises(InvalidParameterError, match="Metrics cannot be collected for engine with no observer"):
         engine.get_streaming_metrics_listener(metrics_config=OutputConfig(location="dummy"))
+
+
+def test_verify_workspace_client_with_null_product_info(mock_spark):
+    ws = create_autospec(WorkspaceClient)
+    mock_config = Mock()
+    mock_config._product_info = None
+    ws.config = mock_config
+
+    DQEngine(spark=mock_spark, workspace_client=ws)
+
+    assert mock_config._product_info == ('dqx', __version__)
+
+
+def test_verify_workspace_client_with_non_dqx_product_info(mock_spark):
+    ws = create_autospec(WorkspaceClient)
+    mock_config = Mock()
+    mock_config._product_info = ('other-product', '1.0.0')
+    ws.config = mock_config
+
+    DQEngine(spark=mock_spark, workspace_client=ws)
+
+    assert mock_config._product_info == ('dqx', __version__)


### PR DESCRIPTION
## Changes
Defaulted product to dqx, and product_version = __version__, if the product_info is None.

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #980 

### Tests
Unit Test have been created to test both None, and non dqx values

- [x] manually tested
- [x] added unit tests
- [ ] added integration tests
- [ ] added end-to-end tests
- [ ] added performance tests
