### PR TITLE
feat(profiler): add percentile calculation (p10, p90)

### DIFF
--- a/src/databricks/labs/dqx/profiler/profiler.py
+++ b/src/databricks/labs/dqx/profiler/profiler.py
@@ -75,6 +75,7 @@ class DQProfiler(DQEngineBase):
         "limit": 1000,  # limit the number of samples
         "filter": None,  # filter to apply to the dataset
         "llm_primary_key_detection": True,  # detect primary keys
+        "percentiles": [0.1, 0.9],  # percentiles to calculate (p10, p90)
     }
 
     @staticmethod
@@ -529,6 +530,8 @@ class DQProfiler(DQEngineBase):
             rule = self._extract_min_max(dst, field_name, typ, metrics, opts)
             if rule:
                 dq_rules.append(rule)
+            # Calculate percentiles (p10, p90 by default)
+            self._calculate_percentiles(dst, field_name, typ, metrics, opts)
 
     def _get_df_summary_as_dict(self, df: DataFrame) -> dict[str, Any]:
         """
@@ -613,6 +616,60 @@ class DQProfiler(DQEngineBase):
             return self._round_decimal(value, direction)
 
         return value
+
+    def _calculate_percentiles(
+        self,
+        dst: DataFrame,
+        col_name: str,
+        typ: T.DataType,
+        metrics: dict[str, Any],
+        opts: dict[str, Any] | None = None,
+    ) -> None:
+        """
+        Calculates percentiles for a numeric column and adds them to metrics.
+
+        Args:
+            dst: The DataFrame with the column to calculate percentiles for.
+            col_name: The name of the column.
+            typ: The data type of the column.
+            metrics: A dictionary to store the calculated percentile metrics.
+            opts: A dictionary of options for percentile calculation.
+        """
+        if opts is None:
+            opts = {}
+
+        # Get configured percentiles, default to p10 and p90
+        percentiles = opts.get("percentiles", [0.1, 0.9])
+
+        # Only calculate for numeric types
+        if not self._type_supports_min_max(typ):
+            return
+
+        # Skip for string/boolean types
+        if typ in {T.StringType(), T.BooleanType()}:
+            return
+
+        column = col_name
+        if typ == T.DateType():
+            dst = dst.select(F.col(column).cast("timestamp").cast("bigint").alias(column))
+            column = F.col(column).cast("double")
+        elif typ == T.TimestampType():
+            dst = dst.select(F.col(column).cast("bigint").alias(column))
+            column = F.col(column).cast("double")
+        elif typ == T.DoubleType() or typ == T.FloatType():
+            column = F.col(column).cast("double")
+
+        # Build the aggregation expression for percentiles
+        try:
+            pct_agg = dst.agg(F.percentile_approx(column, percentiles)).collect()
+            if pct_agg and pct_agg[0]:
+                pct_values = pct_agg[0][0]
+                if pct_values and len(pct_values) == len(percentiles):
+                    for i, pct in enumerate(percentiles):
+                        pct_key = f"p{int(pct * 100)}"
+                        metrics[pct_key] = self._round_value(pct_values[i], "nearest", opts)
+        except Exception as e:
+            logger.debug(f"Could not calculate percentiles for {col_name}: {e}")
 
     def _extract_min_max(
         self,


### PR DESCRIPTION
## Summary

Extends DQProfiler to calculate percentiles for numeric columns using Spark's percentile_approx function.

## Changes

- Added percentiles option to default_profile_options (default: [0.1, 0.9] for p10/p90)
- Added _calculate_percentiles method that calculates percentiles alongside min/max
- Percentiles are stored in metrics dict as p10, p90 keys

## Linked Issue

Closes databrickslabs/dqx#1067

## Implementation Notes

- Uses Spark's percentile_approx for efficient approximate percentile calculation
- Percentiles are calculated for numeric types: integers, doubles, floats, dates, timestamps
- Skipped for string and boolean types
- Gracefully handles errors (logs at debug level)
- Follows existing pattern of using _round_value for consistent rounding

## Testing

The changes follow the existing code patterns in the profiler. Unit tests would require a Spark environment to run locally. The code compiles without syntax errors.