### PR TITLE
fix(datacontract): don't eagerly import DQLLMEngine for a type hint (#1168)

### DIFF
--- a/src/databricks/labs/dqx/datacontract/contract_rules_generator.py
+++ b/src/databricks/labs/dqx/datacontract/contract_rules_generator.py
@@ -34,13 +34,11 @@ from databricks.labs.dqx.errors import InvalidPhysicalTypeError, ODCSContractErr
 from databricks.labs.dqx.telemetry import telemetry_logger
 from databricks.labs.dqx.package_utils import missing_required_packages
 
-# DQLLMEngine is referenced only as a type annotation on __init__. Eagerly
-# importing it forces the [llm] extras to be installed even for callers who
-# don't use text-based rules — and when those extras aren't installed, the
-# resulting ImportError is caught by a broad try/except in profiler/generator.py
-# which then disables the entire datacontract feature with a misleading
-# "install datacontract-cli" error. See #1168.
-if TYPE_CHECKING:
+# DQLLMEngine is referenced only as a type annotation. Eagerly importing it
+# requires installation of [llm] extras which may not be installed or wanted
+# by the user. If llm_engine is specified and [llm] extras are not installed,
+# an error is raised when instantiating the DataContractRulesGenerator.
+if TYPE_CHECKING:  # pragma: no cover
     from databricks.labs.dqx.llm.llm_engine import DQLLMEngine
 
 logger = logging.getLogger(__name__)

--- a/src/databricks/labs/dqx/datacontract/contract_rules_generator.py
+++ b/src/databricks/labs/dqx/datacontract/contract_rules_generator.py
@@ -12,7 +12,7 @@ import logging
 import re
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import yaml
 
@@ -33,7 +33,15 @@ from databricks.labs.dqx.engine import DQEngine
 from databricks.labs.dqx.errors import InvalidPhysicalTypeError, ODCSContractError, ParameterError
 from databricks.labs.dqx.telemetry import telemetry_logger
 from databricks.labs.dqx.package_utils import missing_required_packages
-from databricks.labs.dqx.llm.llm_engine import DQLLMEngine  # type: ignore
+
+# DQLLMEngine is referenced only as a type annotation on __init__. Eagerly
+# importing it forces the [llm] extras to be installed even for callers who
+# don't use text-based rules — and when those extras aren't installed, the
+# resulting ImportError is caught by a broad try/except in profiler/generator.py
+# which then disables the entire datacontract feature with a misleading
+# "install datacontract-cli" error. See #1168.
+if TYPE_CHECKING:
+    from databricks.labs.dqx.llm.llm_engine import DQLLMEngine
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +58,7 @@ class DataContractRulesGenerator(DQEngineBase):
     def __init__(
         self,
         workspace_client: WorkspaceClient,
-        llm_engine: DQLLMEngine | None = None,
+        llm_engine: "DQLLMEngine | None" = None,
         custom_check_functions: dict[str, Callable] | None = None,
     ):
         """


### PR DESCRIPTION
## Summary

Fixes #1168. `DQLLMEngine` was imported unconditionally at the top of `contract_rules_generator.py` purely for the type annotation `llm_engine: DQLLMEngine | None = None` on the constructor. The class is never instantiated when `llm_engine=None` (the default) or when `process_text_rules=False`.

When the `[llm]` extras aren't installed, that import raises `ImportError`. The broad `try/except` in `profiler/generator.py` catches it and silently sets `DATACONTRACT_ENABLED = False`, so any subsequent call to `generate_rules_from_contract` raises `MissingParameterError` with a misleading *"install datacontract-cli"* message — even though `datacontract-cli` is in fact installed.

## Change

Move the import inside `if TYPE_CHECKING:` and quote the annotation. The name resolves correctly for static type checkers (mypy, pyright); the runtime never attempts the import; the broad `except` no longer fires for this reason.

```diff
-from typing import Any
+from typing import TYPE_CHECKING, Any
 ...
-from databricks.labs.dqx.llm.llm_engine import DQLLMEngine  # type: ignore
+if TYPE_CHECKING:
+    from databricks.labs.dqx.llm.llm_engine import DQLLMEngine
 ...
-        llm_engine: DQLLMEngine | None = None,
+        llm_engine: "DQLLMEngine | None" = None,
```

## Reproducer

Fresh DQX 0.14.0 install on Databricks serverless (Python 3.12), no `[llm]` extras:

```
find_spec('datacontract')                       = .../site-packages/datacontract/__init__.py
find_spec('datacontract.data_contract')         = ...data_contract.py
find_spec('open_data_contract_standard.model')  = ...model.py
find_spec('databricks.labs.dqx.llm.llm_engine') RAISED ImportError: llm extras not installed.
import databricks.labs.dqx.datacontract.contract_rules_generator
                                                FAILED ImportError: llm extras not installed.
DATACONTRACT_ENABLED = False
```

With this patch applied, `DATACONTRACT_ENABLED = True` and `generate_rules_from_contract(..., process_text_rules=False)` works end-to-end without `[llm]` extras.

## Test plan

- [ ] Unit test that imports `contract_rules_generator` after monkey-patching `databricks.labs.dqx.llm.llm_engine` out of `sys.modules` (simulates missing `[llm]` extras) — would have caught this.
- [x] Manual verification: run `generate_rules_from_contract(contract_file=..., process_text_rules=False)` in a fresh Python 3.12 env with `databricks-labs-dqx` + `datacontract-cli` but no `[llm]` extras — succeeds with this patch, fails without.

This pull request and its description were written by Isaac.