### PR TITLE
docs: rename `user` to `client_id` in `LakebaseChecksStorageConfig`

### DIFF
--- a/docs/dqx/docs/guide/quality_checks_storage.mdx
+++ b/docs/dqx/docs/guide/quality_checks_storage.mdx
@@ -69,7 +69,7 @@ If you create checks as a list of `DQRule` objects, you can convert them to meta
     dq_engine.save_checks(checks, config=VolumeFileChecksStorageConfig(location="/Volumes/dq/config/checks_volume/App1/checks.yml"))
 
     # save checks as a Lakebase table using a Databricks service principal
-    dq_engine.save_checks(checks, config=LakebaseChecksStorageConfig(instance_name="my-instance", user="00000000-0000-0000-0000-000000000000", location="dqx.config.checks"))
+    dq_engine.save_checks(checks, config=LakebaseChecksStorageConfig(instance_name="my-instance", client_id="00000000-0000-0000-0000-000000000000", location="dqx.config.checks"))
     
     # save checks as a YAML file or table defined in 'checks_location' of the run config
     # only works if DQX is installed in the workspace
@@ -202,10 +202,10 @@ If you create checks as a list of DQRule objects, you can convert them using the
     checks: list[dict] = dq_engine.load_checks(config=VolumeFileChecksStorageConfig(location="/Volumes/dq/config/checks_volume/App1/checks.yml"))
 
     # load checks from a Lakebase table using a Databricks service principal
-    checks: list[dict] = dq_engine.load_checks(config=LakebaseChecksStorageConfig(instance_name="my-instance", user="00000000-0000-0000-0000-000000000000", location="dqx.config.checks"))
+    checks: list[dict] = dq_engine.load_checks(config=LakebaseChecksStorageConfig(instance_name="my-instance", client_id="00000000-0000-0000-0000-000000000000", location="dqx.config.checks"))
 
     # load checks from a Lakebase table using specific rule_set_fingerprint for filtering (it can be any rule_set_fingerprint from checks_table)
-    checks: list[dict] = dq_engine.load_checks(config=LakebaseChecksStorageConfig(instance_name="my-instance", user="00000000-0000-0000-0000-000000000000", location="dqx.config.checks", rule_set_fingerprint="9664332437da274d921cefac60bd509e0aa383292ba695341e1f3fbc2a716e48"))
+    checks: list[dict] = dq_engine.load_checks(config=LakebaseChecksStorageConfig(instance_name="my-instance", client_id="00000000-0000-0000-0000-000000000000", location="dqx.config.checks", rule_set_fingerprint="9664332437da274d921cefac60bd509e0aa383292ba695341e1f3fbc2a716e48"))
 
     # load checks from a file or table defined in the run config ('checks_location' field)
     # only works if DQX is installed in the workspace
@@ -245,7 +245,7 @@ The following backend configuration are currently supported:
     * `location`: Unity Catalog Volume file path (JSON or YAML).
 * `LakebaseChecksStorageConfig`: Lakebase table. Uses the same structure and compact format as Delta tables (`for_each_column` preserved). Containing fields:
     * `instance_name`: name of the Lakebase instance, e.g., "my-instance".
-    * `user`: user to connect to the Lakebase instance, e.g., "user@domain.com" or Databricks service principal client ID.
+    * `client_id`: ID of the Databricks service principal to use for the Lakebase connection.
     * `location`: fully-qualified table name in the format "database.schema.table".
     * `port`: (optional) port on which to connect to the Lakebase instance (use 5432 if not provided).
     * `run_config_name`: (optional) run configuration name to load (use "default" if not provided).


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary -->
Update the argument description and code examples in the [Loading and Storing Quality Checks](https://databrickslabs.github.io/dqx/docs/guide/quality_checks_storage/) docs page to reflect the actual argument name in [`LakebaseChecksStorageConfig`](https://github.com/databrickslabs/dqx/blob/main/src/databricks/labs/dqx/config.py#L368), which uses `client_id: str | None = None`, not `user`. The previous docs referred to `user` and incorrectly described it as accepting a `user@domain.com` format.

- Renamed `user` to `client_id` in save/load examples
- Updated bullet description in supported storage backends section

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] added end-to-end tests
- [ ] added performance tests

### Documentation and Demos
<!-- Any user facing changes require documentation and demos update -->

- [ ] added/updated demos
- [x] added/updated docs
- [ ] added/updated agent skills