### PR TITLE
Fork test: PR #1191 - fix(datacontract): don't eagerly import DQLLMEngine for a type hint (#1168)

### DIFF
--- a/src/databricks/labs/dqx/datacontract/contract_rules_generator.py
+++ b/src/databricks/labs/dqx/datacontract/contract_rules_generator.py
@@ -34,13 +34,11 @@ from databricks.labs.dqx.errors import InvalidPhysicalTypeError, ODCSContractErr
 from databricks.labs.dqx.telemetry import telemetry_logger
 from databricks.labs.dqx.package_utils import missing_required_packages
 
-# DQLLMEngine is referenced only as a type annotation on __init__. Eagerly
-# importing it forces the [llm] extras to be installed even for callers who
-# don't use text-based rules — and when those extras aren't installed, the
-# resulting ImportError is caught by a broad try/except in profiler/generator.py
-# which then disables the entire datacontract feature with a misleading
-# "install datacontract-cli" error. See #1168.
-if TYPE_CHECKING:
+# DQLLMEngine is referenced only as a type annotation. Eagerly importing it
+# requires installation of [llm] extras which may not be installed or wanted
+# by the user. If llm_engine is specified and [llm] extras are not installed,
+# an error is raised when instantiating the DataContractRulesGenerator.
+if TYPE_CHECKING:  # pragma: no cover
     from databricks.labs.dqx.llm.llm_engine import DQLLMEngine
 
 logger = logging.getLogger(__name__)

--- a/src/databricks/labs/dqx/datacontract/contract_rules_generator.py
+++ b/src/databricks/labs/dqx/datacontract/contract_rules_generator.py
@@ -12,7 +12,7 @@ import logging
 import re
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import yaml
 
@@ -33,7 +33,15 @@ from databricks.labs.dqx.engine import DQEngine
 from databricks.labs.dqx.errors import InvalidPhysicalTypeError, ODCSContractError, ParameterError
 from databricks.labs.dqx.telemetry import telemetry_logger
 from databricks.labs.dqx.package_utils import missing_required_packages
-from databricks.labs.dqx.llm.llm_engine import DQLLMEngine  # type: ignore
+
+# DQLLMEngine is referenced only as a type annotation on __init__. Eagerly
+# importing it forces the [llm] extras to be installed even for callers who
+# don't use text-based rules — and when those extras aren't installed, the
+# resulting ImportError is caught by a broad try/except in profiler/generator.py
+# which then disables the entire datacontract feature with a misleading
+# "install datacontract-cli" error. See #1168.
+if TYPE_CHECKING:
+    from databricks.labs.dqx.llm.llm_engine import DQLLMEngine
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +58,7 @@ class DataContractRulesGenerator(DQEngineBase):
     def __init__(
         self,
         workspace_client: WorkspaceClient,
-        llm_engine: DQLLMEngine | None = None,
+        llm_engine: "DQLLMEngine | None" = None,
         custom_check_functions: dict[str, Callable] | None = None,
     ):
         """


### PR DESCRIPTION
Automated sync from fork PR for CI testing.

Original PR: https://github.com/databrickslabs/dqx/pull/1191

All tests, including unit and integration tests run on this PR (they are skipped for fork PRs).