### PR TITLE
fix(docs): simplify tolerance docstring examples in check_funcs.py

### DIFF
--- a/docs/dqx/docs/dev/docs_authoring.mdx
+++ b/docs/dqx/docs/dev/docs_authoring.mdx
@@ -155,10 +155,10 @@ The API docs are generated in the `docs/dqx/docs/reference/api` directory.
 
 To generate API docs, run the following command:
 ```shell
-hatch run docs:pydoc-markdown
+uv run --group docs pydoc-markdown
 ```
 
-This command is run also as part of make docs build and server.
+This is the same invocation that `make docs-build` and `make docs-serve-dev` run, so the recommended way is simply `make docs-build`.
 The command will generate the API documentation from the Python codebase using pydoc-markdown.
 
 For best practices on writing docstrings, refer to this [guidance](/docs/dev/contributing#writing-docstrings).

--- a/docs/dqx/docs/guide/quality_dashboard.mdx
+++ b/docs/dqx/docs/guide/quality_dashboard.mdx
@@ -72,3 +72,43 @@ How to locate the dashboard:
   </TabItem>
 </Tabs>
 
+## Connecting a Genie Space
+
+You can link a [Databricks Genie Space](https://docs.databricks.com/aws/en/genie/index.html) to the DQX dashboard so that dashboard viewers can ask natural-language questions against the dashboard data — without leaving the dashboard.
+
+### Prerequisites
+
+Before starting, confirm that:
+
+- The Genie capability is enabled in your Databricks workspace.
+- The Genie space you want to link already exists and has been shared with the right users or groups.
+- Users who will interact with the linked Genie space have the appropriate Databricks access entitlement and at least `SELECT` privileges on the Unity Catalog data objects used by the space.
+
+To link the Genie space:
+
+1. Open the DQX dashboard in Databricks in **Edit Draft** mode.
+2. In the right-hand panel, click **Settings**. You can also open settings from the kebab menu (⋮) and choose **Settings**.
+3. Open the **General** section.
+4. Make sure **Enable Genie** is turned on.
+5. Select **Link existing Genie space**.
+6. Paste the URL of the existing Genie space into the field provided.
+7. Publish or republish the dashboard so viewers can use the linked Genie experience.
+
+To get the Genie space URL: open the Genie space, click **Share**, and use **Copy link**.
+
+<Admonition type="info" title="Auto-generated Genie space">
+If no existing space is linked, Databricks automatically generates a new companion Genie space from the dashboard when it is published and Genie is enabled.
+</Admonition>
+
+<Admonition type="warning" title="Data exposure">
+Questions asked through Genie are answered from the full dataset query results behind the dashboard, not only from what is currently visible in the charts. Sensitive rows or columns included in the dataset can be exposed through Genie even if they are not shown in a visualization.
+</Admonition>
+
+### Troubleshooting
+
+**Genie option is unavailable:** Check whether Genie is enabled for the account and workspace.
+
+**Users can open the dashboard but not ask questions:** Verify Databricks SQL or consumer access entitlement and confirm users have permission on the underlying Unity Catalog objects.
+
+**Wrong or overly broad answers:** Review the Genie space configuration, attached data sources, and instructions. Genie can query beyond explicitly attached tables if permissions and context allow it.
+

--- a/src/databricks/labs/dqx/check_funcs.py
+++ b/src/databricks/labs/dqx/check_funcs.py
@@ -645,15 +645,9 @@ def is_equal_to(
         column (str | Column): Column to check. Can be a string column name or a column expression.
         value: The value to compare with. Can be a number, date, timestamp literal or a Spark Column. Defaults to None.
         abs_tolerance: Values are considered equal if the absolute difference is less than or equal to the tolerance. This is applicable to numeric columns.
-                Example: abs(a - b) <= tolerance
-                With tolerance=0.01:
-                    2.001 and 2.0099 → equal (diff = 0.0089)
-                    2.001 and 2.02 → not equal (diff = 0.019)
+            For example, abs(a - b) <= tolerance. With abs_tolerance=0.01, values 2.001 and 2.0099 are equal (diff=0.0089), but 2.001 and 2.02 are not (diff=0.019).
         rel_tolerance: Relative tolerance for numeric comparisons. Differences within this relative tolerance are ignored. Useful if numbers vary in scale.
-                Example: abs(a - b) <= rel_tolerance * max(abs(a), abs(b))
-                With tolerance=0.01 (1%):
-                    100 vs 101 → equal (diff = 1, tolerance = 1)
-                    100 vs 102 → not equal (diff = 2, tolerance = 1)
+            For example, abs(a - b) <= rel_tolerance * max(abs(a), abs(b)). With rel_tolerance=0.01 (1%), values 100 and 101 are equal (diff=1), but 100 and 102 are not (diff=2).
     Returns:
         Column: A Spark Column condition that fails if the column value is not equal to the given value.
 
@@ -706,15 +700,9 @@ def is_not_equal_to(
         column (str | Column): Column to check. Can be a string column name or a column expression.
         value: The value to compare with. Can be a number, date, timestamp literal or a Spark Column. Defaults to None.
         abs_tolerance: Values are considered equal if the absolute difference is less than or equal to the tolerance. This is applicable to numeric columns.
-                Example: abs(a - b) <= tolerance
-                With tolerance=0.01:
-                    2.001 and 2.0099 → equal (diff = 0.0089)
-                    2.001 and 2.02 → not equal (diff = 0.019)
+            For example, abs(a - b) <= tolerance. With abs_tolerance=0.01, values 2.001 and 2.0099 are equal (diff=0.0089), but 2.001 and 2.02 are not (diff=0.019).
         rel_tolerance: Relative tolerance for numeric comparisons. Differences within this relative tolerance are ignored. Useful if numbers vary in scale.
-                Example: abs(a - b) <= rel_tolerance * max(abs(a), abs(b))
-                With tolerance=0.01 (1%):
-                    100 vs 101 → equal (diff = 1, tolerance = 1)
-                    100 vs 102 → not equal (diff = 2, tolerance = 1)
+            For example, abs(a - b) <= rel_tolerance * max(abs(a), abs(b)). With rel_tolerance=0.01 (1%), values 100 and 101 are equal (diff=1), but 100 and 102 are not (diff=2).
 
     Returns:
         Column: A Spark Column condition that fails if the column value is equal to the given value.
@@ -2134,15 +2122,9 @@ def compare_datasets(
         If enabled, (NULL, NULL) column values are equal and matching.
       row_filter: Optional SQL expression to filter rows in the input DataFrame. Auto-injected from the check filter.
       abs_tolerance: Values are considered equal if the absolute difference is less than or equal to the tolerance. This is applicable to numeric columns.
-            Example: abs(a - b) <= tolerance
-            With tolerance=0.01:
-            2.001 and 2.0099 → equal (diff = 0.0089)
-            2.001 and 2.02 → not equal (diff = 0.019)
+        For example, abs(a - b) <= tolerance. With abs_tolerance=0.01, values 2.001 and 2.0099 are equal (diff=0.0089), but 2.001 and 2.02 are not (diff=0.019).
       rel_tolerance: Relative tolerance for numeric comparisons. Differences within this relative tolerance are ignored. Useful if numbers vary in scale.
-            Example: abs(a - b) <= rel_tolerance * max(abs(a), abs(b))
-            With tolerance=0.01 (1%):
-            100 vs 101 → equal (diff = 1, tolerance = 1)
-            2.001 vs 2.0099 → equal
+        For example, abs(a - b) <= rel_tolerance * max(abs(a), abs(b)). With rel_tolerance=0.01 (1%), values 100 and 101 are equal (diff=1), but 100 and 102 are not (diff=2).
 
 
     Returns:
@@ -3073,9 +3055,9 @@ def _add_column_diffs(
             If enabled (NULL, NULL) column values are equal and matching.
             If False, uses a standard inequality comparison (`!=`), where (NULL, NULL) values are not considered equal.
         abs_tolerance: Absolute tolerance for numeric comparisons. Differences within this absolute tolerance are ignored.
-            Example: abs(a - b) <= abs_tolerance
+            For example, abs(a - b) <= abs_tolerance
         rel_tolerance: Relative tolerance for numeric comparisons. Differences within this relative tolerance are ignored.
-            Example: abs(a - b) <= rel_tolerance * max(abs(a), abs(b))
+            For example, abs(a - b) <= rel_tolerance * max(abs(a), abs(b))
     Returns:
         A DataFrame with the added *columns_changed_col* containing the map of changed columns and differences.
     """


### PR DESCRIPTION
## Changes
## Summary
  - Simplified `abs_tolerance` and `rel_tolerance` docstring examples in `is_equal_to`, `is_not_equal_to`, `compare_datasets`, and `_add_column_diffs` to use inline prose instead of multi-line indented blocks.
  - Replaced `Example:` with `For example,` `compare_datasets`, and `_add_column_diffs` to use inline prose instead of multi-line indented blocks.

### Tests
- [x] manually tested

#### Before change
<img width="2074" height="1274" alt="Screenshot 2026-05-29 at 11 29 32" src="https://github.com/user-attachments/assets/ce61dfef-436f-43c5-8d00-454a67b4dc2e" />

#### After change
<img width="1032" height="568" alt="Screenshot 2026-06-17 at 11 53 08" src="https://github.com/user-attachments/assets/df40582c-abd2-420d-98a1-85482d77aacd" />

