### PR TITLE
docs(dashboard): add Genie Space connection guide (#1248)

### DIFF
--- a/docs/dqx/docs/guide/quality_dashboard.mdx
+++ b/docs/dqx/docs/guide/quality_dashboard.mdx
@@ -72,3 +72,43 @@ How to locate the dashboard:
   </TabItem>
 </Tabs>
 
+## Connecting a Genie Space
+
+You can link a [Databricks Genie Space](https://docs.databricks.com/aws/en/genie/index.html) to the DQX dashboard so that dashboard viewers can ask natural-language questions against the dashboard data — without leaving the dashboard.
+
+### Prerequisites
+
+Before starting, confirm that:
+
+- The Genie capability is enabled in your Databricks workspace.
+- The Genie space you want to link already exists and has been shared with the right users or groups.
+- Users who will interact with the linked Genie space have the appropriate Databricks access entitlement and at least `SELECT` privileges on the Unity Catalog data objects used by the space.
+
+To link the Genie space:
+
+1. Open the DQX dashboard in Databricks in **Edit Draft** mode.
+2. In the right-hand panel, click **Settings**. You can also open settings from the kebab menu (⋮) and choose **Settings**.
+3. Open the **General** section.
+4. Make sure **Enable Genie** is turned on.
+5. Select **Link existing Genie space**.
+6. Paste the URL of the existing Genie space into the field provided.
+7. Publish or republish the dashboard so viewers can use the linked Genie experience.
+
+To get the Genie space URL: open the Genie space, click **Share**, and use **Copy link**.
+
+<Admonition type="info" title="Auto-generated Genie space">
+If no existing space is linked, Databricks automatically generates a new companion Genie space from the dashboard when it is published and Genie is enabled.
+</Admonition>
+
+<Admonition type="warning" title="Data exposure">
+Questions asked through Genie are answered from the full dataset query results behind the dashboard, not only from what is currently visible in the charts. Sensitive rows or columns included in the dataset can be exposed through Genie even if they are not shown in a visualization.
+</Admonition>
+
+### Troubleshooting
+
+**Genie option is unavailable:** Check whether Genie is enabled for the account and workspace.
+
+**Users can open the dashboard but not ask questions:** Verify Databricks SQL or consumer access entitlement and confirm users have permission on the underlying Unity Catalog objects.
+
+**Wrong or overly broad answers:** Review the Genie space configuration, attached data sources, and instructions. Genie can query beyond explicitly attached tables if permissions and context allow it.
+


### PR DESCRIPTION
### Changes
adds a **Connecting a Genie Space** section to the Quality Dashboard guide, covering prerequisites, step-by-step setup, how to get the Genie space URL, important notes on data exposure, and troubleshooting. content is based on the PDF attached to the issue.

### Linked issues
resolves #1248

### Tests
- [ ] manually tested
- [ ] added unit tests
- [ ] added integration tests
- [ ] added end-to-end tests
- [ ] added performance tests

### Documentation and Demos
- [ ] added/updated demos
- [x] added/updated docs
- [ ] added/updated agent skills
