### PR TITLE
Guard LLM-generated sql_query rules

### DIFF
--- a/src/databricks/labs/dqx/llm/llm_core.py
+++ b/src/databricks/labs/dqx/llm/llm_core.py
@@ -7,10 +7,60 @@ import dspy  # type: ignore
 
 from databricks.labs.dqx.config import LLMModelConfig
 from databricks.labs.dqx.llm.llm_utils import create_optimizer_training_set, create_optimizer_training_set_with_stats
+from databricks.labs.dqx.utils import is_sql_query_safe
 from databricks.labs.dqx.llm.optimizers import BootstrapFewShotOptimizer
 from databricks.labs.dqx.llm.validators import RuleValidator
 
 logger = logging.getLogger(__name__)
+
+
+def _filter_unsafe_sql_rules(rules_json: str) -> str:
+    """Filter out any sql_query rules whose query argument fails the SQL safety check.
+
+    Parses the JSON rules array and drops every rule where *check.function* is
+    *sql_query* and the *query* argument does not pass *is_sql_query_safe*. All
+    other rules are returned unchanged. If the input cannot be parsed as a JSON
+    array the original string is returned so the caller's JSON-validation step
+    handles it.
+
+    Args:
+        rules_json: JSON string containing the generated rules array.
+
+    Returns:
+        JSON string with unsafe sql_query rules removed, or the original string
+        when it cannot be parsed.
+    """
+    try:
+        rules = json.loads(rules_json)
+    except (json.JSONDecodeError, ValueError):
+        return rules_json
+
+    if not isinstance(rules, list):
+        return "[]"
+
+    safe_rules = []
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+
+        check = rule.get("check", {})
+        if not isinstance(check, dict):
+            continue
+
+        if check.get("function") == "sql_query":
+            arguments = check.get("arguments", {})
+            if not isinstance(arguments, dict):
+                continue
+
+            query = arguments.get("query") or ""
+            if not is_sql_query_safe(query):
+                # Strip control characters before logging to prevent log injection (CWE-117)
+                safe_repr = repr(query.replace("\n", " ").replace("\r", " "))
+                logger.warning(f"LLM-generated sql_query rule dropped: unsafe SQL query {safe_repr}")
+                continue
+        safe_rules.append(rule)
+
+    return json.dumps(safe_rules)
 
 
 class LLMModelConfigurator:
@@ -147,13 +197,15 @@ class DspyRuleGeneration(dspy.Module):
             schema_info=schema_info, business_description=business_description, available_functions=available_functions
         )
 
-        # Validate JSON output
+        # Validate JSON output and filter unsafe sql_query rules
         if result.quality_rules:
             try:
                 json.loads(result.quality_rules)
             except json.JSONDecodeError as e:
                 logger.warning(f"Generated invalid JSON: {e}. Returning empty rules.")
                 result.quality_rules = "[]"
+            else:
+                result.quality_rules = _filter_unsafe_sql_rules(result.quality_rules)
 
         return result
 
@@ -275,13 +327,15 @@ class DspyRuleUsingDataStats(dspy.Module):
             business_description=business_description or "",
         )
 
-        # Validate JSON output
+        # Validate JSON output and filter unsafe sql_query rules
         if result.quality_rules:
             try:
                 json.loads(result.quality_rules)
             except json.JSONDecodeError as e:
                 logger.warning(f"Generated invalid JSON: {e}. Returning empty rules.")
                 result.quality_rules = "[]"
+            else:
+                result.quality_rules = _filter_unsafe_sql_rules(result.quality_rules)
 
         return result
 

--- a/src/databricks/labs/dqx/llm/llm_core.py
+++ b/src/databricks/labs/dqx/llm/llm_core.py
@@ -14,31 +14,24 @@ from databricks.labs.dqx.llm.validators import RuleValidator
 logger = logging.getLogger(__name__)
 
 
-def _filter_unsafe_sql_rules(rules_json: str) -> str:
+def _filter_unsafe_sql_rules(rules: object) -> list[dict]:
     """Filter out any sql_query rules whose query argument fails the SQL safety check.
 
-    Parses the JSON rules array and drops every rule where *check.function* is
-    *sql_query* and the *query* argument does not pass *is_sql_query_safe*. All
-    other rules are returned unchanged. If the input cannot be parsed as a JSON
-    array the original string is returned so the caller's JSON-validation step
-    handles it.
+    Accepts a pre-parsed rules value and drops every rule where *check.function* is
+    *sql_query* and the *query* argument is not a string or does not pass
+    *is_sql_query_safe*. All other rules are returned unchanged. Non-list input
+    returns an empty list.
 
     Args:
-        rules_json: JSON string containing the generated rules array.
+        rules: Parsed rules value (expected to be a list of rule dicts).
 
     Returns:
-        JSON string with unsafe sql_query rules removed, or the original string
-        when it cannot be parsed.
+        List of safe rules with unsafe sql_query rules removed.
     """
-    try:
-        rules = json.loads(rules_json)
-    except (json.JSONDecodeError, ValueError):
-        return rules_json
-
     if not isinstance(rules, list):
-        return "[]"
+        return []
 
-    safe_rules = []
+    safe_rules: list[dict] = []
     for rule in rules:
         if not isinstance(rule, dict):
             continue
@@ -52,15 +45,19 @@ def _filter_unsafe_sql_rules(rules_json: str) -> str:
             if not isinstance(arguments, dict):
                 continue
 
-            query = arguments.get("query") or ""
+            query = arguments.get("query")
+            if not isinstance(query, str):
+                logger.warning(f"LLM-generated sql_query rule dropped: non-string query argument {query!r}")
+                continue
             if not is_sql_query_safe(query):
                 # Strip control characters before logging to prevent log injection (CWE-117)
                 safe_repr = repr(query.replace("\n", " ").replace("\r", " "))
                 logger.warning(f"LLM-generated sql_query rule dropped: unsafe SQL query {safe_repr}")
                 continue
+
         safe_rules.append(rule)
 
-    return json.dumps(safe_rules)
+    return safe_rules
 
 
 class LLMModelConfigurator:
@@ -200,12 +197,12 @@ class DspyRuleGeneration(dspy.Module):
         # Validate JSON output and filter unsafe sql_query rules
         if result.quality_rules:
             try:
-                json.loads(result.quality_rules)
+                parsed = json.loads(result.quality_rules)
             except json.JSONDecodeError as e:
                 logger.warning(f"Generated invalid JSON: {e}. Returning empty rules.")
                 result.quality_rules = "[]"
             else:
-                result.quality_rules = _filter_unsafe_sql_rules(result.quality_rules)
+                result.quality_rules = json.dumps(_filter_unsafe_sql_rules(parsed))
 
         return result
 
@@ -330,12 +327,12 @@ class DspyRuleUsingDataStats(dspy.Module):
         # Validate JSON output and filter unsafe sql_query rules
         if result.quality_rules:
             try:
-                json.loads(result.quality_rules)
+                parsed = json.loads(result.quality_rules)
             except json.JSONDecodeError as e:
                 logger.warning(f"Generated invalid JSON: {e}. Returning empty rules.")
                 result.quality_rules = "[]"
             else:
-                result.quality_rules = _filter_unsafe_sql_rules(result.quality_rules)
+                result.quality_rules = json.dumps(_filter_unsafe_sql_rules(parsed))
 
         return result
 

--- a/src/databricks/labs/dqx/llm/resources/training_examples_with_stats.yml
+++ b/src/databricks/labs/dqx/llm/resources/training_examples_with_stats.yml
@@ -104,7 +104,7 @@
       mean: null
       min: "active"
       max: "suspended"
-  quality_rules: '[{"criticality":"warn","check":{"function":"is_not_null_and_not_empty","arguments":{"column":"email"}}},{"criticality":"error","check":{"function":"is_email","arguments":{"column":"email"}}}]'
+  quality_rules: '[{"criticality":"warn","check":{"function":"is_not_null_and_not_empty","arguments":{"column":"email"}}},{"criticality":"error","check":{"function":"is_valid_email","arguments":{"column":"email"}}}]'
   reasoning: "Email should be present for all user accounts and follow valid format. Combining completeness and format validation ensures high-quality contact information."
 
 - name: "order_total_within_daily_average_sql_query"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -899,12 +899,24 @@ def _lakebase_create_catalog(
 
 @retried(on=[BadRequest, TooManyRequests, RequestLimitExceeded], timeout=timedelta(minutes=2))
 def _lakebase_delete_catalog(workspace: WorkspaceClient, catalog_name: str) -> None:
-    """Delete database catalog; retries on rate limits."""
+    """Delete the database catalog and ensure its Unity Catalog catalog is removed; retries on limits.
+
+    delete_database_catalog tears down the database federation, but the UC catalog object - which is
+    what counts toward the per-metastore catalog limit (1000) - is removed via catalogs.delete. We
+    call both so the metastore slot is freed regardless of what delete_database_catalog leaves behind.
+    Both are NotFound-safe so a prior/partial deletion is tolerated.
+    """
     try:
         workspace.database.delete_database_catalog(name=catalog_name)
-        logger.info(f"Successfully deleted database catalog: {catalog_name}")
+        logger.info(f"Deleted database catalog: {catalog_name}")
     except NotFound:
         logger.info(f"Database catalog {catalog_name} not found (already deleted)")
+
+    try:
+        workspace.catalogs.delete(name=catalog_name, force=True)
+        logger.info(f"Deleted Unity Catalog catalog backing database catalog: {catalog_name}")
+    except NotFound:
+        logger.info(f"Unity Catalog catalog {catalog_name} not found (already deleted)")
 
 
 @retried(on=[BadRequest, TooManyRequests, RequestLimitExceeded], timeout=timedelta(minutes=2))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -932,8 +932,13 @@ def make_lakebase_instance(ws, make_random):
         return LakebaseInstance(name=instance_name, catalog_name=catalog_name, database_name=database_name)
 
     def delete(instance: LakebaseInstance) -> None:
-        _lakebase_delete_catalog(ws, instance.catalog_name)
-        _lakebase_delete_database_instance(ws, instance.name)
+        # Always attempt instance deletion even if catalog deletion fails, otherwise a failed
+        # catalog delete would orphan the instance. Catalogs count toward the metastore limit,
+        # so deleting the catalog first is intentional.
+        try:
+            _lakebase_delete_catalog(ws, instance.catalog_name)
+        finally:
+            _lakebase_delete_database_instance(ws, instance.name)
 
     yield from factory("lakebase", create, delete)
 

--- a/tests/integration/test_ai_rules_generator.py
+++ b/tests/integration/test_ai_rules_generator.py
@@ -126,11 +126,11 @@ def test_generate_dq_rules_ai_assisted_with_custom_functions(ws, spark):
 
     expected_checks = EXPECTED_CHECKS + [
         {
-            'check': {
-                'arguments': {'column': 'email', 'suffix': '@gmail.com'},
-                'function': 'not_ends_with_suffix',
+            "check": {
+                "arguments": {"column": "email", "suffix": "@gmail.com"},
+                "function": "not_ends_with_suffix",
             },
-            'criticality': 'error',
+            "criticality": "error",
         }
     ]
     assert actual_checks == expected_checks
@@ -206,6 +206,34 @@ def test_generate_dq_rules_ai_assisted_with_summary_stats_only(ws, spark):
     # Verify checks were generated and are valid
     assert len(actual_checks) > 0
     assert not DQEngineCore.validate_checks(actual_checks).has_errors
+
+
+def test_generate_dq_rules_ai_assisted_email_format_with_summary_stats(ws, spark):
+    """Email column from summary stats should yield a valid is_valid_email check.
+
+    Regression for the stats training example that referenced the non-existent
+    `is_email` function (corrected to `is_valid_email`). Previously the model
+    imitated the bad example and the rule was silently dropped by validation,
+    producing no email-format check at all.
+    """
+    user_input = "Email addresses must be present and follow a valid email format."
+    summary_stats = {
+        "email": {"mean": None, "min": "alice@example.com", "max": "zoe@example.com"},
+        "username": {"mean": None, "min": "alice", "max": "zoe"},
+        "account_status": {"mean": None, "min": "active", "max": "suspended"},
+    }
+
+    generator = DQGenerator(ws, spark)
+    actual_checks = generator.generate_dq_rules_ai_assisted(user_input=user_input, summary_stats=summary_stats)
+
+    assert not DQEngineCore.validate_checks(actual_checks).has_errors
+    email_format_checks = [
+        c
+        for c in actual_checks
+        if c.get("check", {}).get("function") == "is_valid_email"
+        and c.get("check", {}).get("arguments", {}).get("column") == "email"
+    ]
+    assert len(email_format_checks) == 1, f"Expected one is_valid_email check for email, got: {actual_checks}"
 
 
 def test_generate_dq_rules_ai_assisted_sql_query_with_custom_input_placeholder(ws, spark):

--- a/tests/integration/test_cleanup.py
+++ b/tests/integration/test_cleanup.py
@@ -1,7 +1,9 @@
 import logging
 import time
 
+from databricks.sdk import WorkspaceClient
 from databricks.sdk.errors import PermissionDenied
+from databricks.sdk.service.catalog import SchemaInfo
 
 from tests.constants import TEST_CATALOG
 
@@ -11,7 +13,7 @@ DUMMY_SCHEMA_PREFIX = "dummy_"
 MAX_AGE_MS = 24 * 60 * 60 * 1000  # only drop objects older than 1 day
 
 
-def test_remove_orhpaned_test_schemas(ws):
+def test_remove_orhpaned_test_schemas(ws: WorkspaceClient) -> None:
     """Maintenance sweep: drop every schema in the test catalog whose name starts with
     ``dummy_`` and that is older than one day, cascading the deletion to all contained
     tables and registered models.
@@ -32,6 +34,9 @@ def test_remove_orhpaned_test_schemas(ws):
 
     skipped: list[str] = []
     for schema in schemas:
+        # Listed schemas always carry these fields; the guard also narrows them for the SDK calls below.
+        if schema.full_name is None or schema.catalog_name is None or schema.name is None:
+            continue
         try:
             # Registered models are not removed by a forced schema delete, so drop them first.
             _drop_registered_models(ws, schema.catalog_name, schema.name)
@@ -42,7 +47,9 @@ def test_remove_orhpaned_test_schemas(ws):
             skipped.append(schema.full_name)
             logger.warning(f"Skipping schema {schema.full_name!r}: no permission to drop it ({exc})")
 
-    remaining = {schema.full_name for schema in _list_stale_dummy_schemas(ws, cutoff_ms)}
+    remaining = {
+        schema.full_name for schema in _list_stale_dummy_schemas(ws, cutoff_ms) if schema.full_name is not None
+    }
     not_permission_skipped = remaining - set(skipped)
     assert not not_permission_skipped, (
         f"Stale schemas with prefix {DUMMY_SCHEMA_PREFIX!r} were not dropped "
@@ -50,7 +57,7 @@ def test_remove_orhpaned_test_schemas(ws):
     )
 
 
-def _list_stale_dummy_schemas(ws, cutoff_ms: int):
+def _list_stale_dummy_schemas(ws: WorkspaceClient, cutoff_ms: int) -> list[SchemaInfo]:
     """Return ``dummy_``-prefixed schemas in the test catalog older than the cutoff."""
     return [
         schema
@@ -61,7 +68,7 @@ def _list_stale_dummy_schemas(ws, cutoff_ms: int):
     ]
 
 
-def _drop_registered_models(ws, catalog_name: str, schema_name: str) -> None:
+def _drop_registered_models(ws: WorkspaceClient, catalog_name: str, schema_name: str) -> None:
     """Delete every registered (Unity Catalog) model in the given schema.
 
     A forced schema delete drops tables and functions but leaves registered models in
@@ -71,7 +78,11 @@ def _drop_registered_models(ws, catalog_name: str, schema_name: str) -> None:
     each version must be deleted first.
     """
     for model in ws.registered_models.list(catalog_name=catalog_name, schema_name=schema_name):
+        if model.full_name is None:
+            continue
         for version in ws.model_versions.list(full_name=model.full_name):
+            if version.version is None:
+                continue
             ws.model_versions.delete(full_name=model.full_name, version=version.version)
             logger.info(f"Deleted model version {model.full_name!r} v{version.version}")
         ws.registered_models.delete(full_name=model.full_name)

--- a/tests/integration/test_save_and_load_checks_from_lakebase_table.py
+++ b/tests/integration/test_save_and_load_checks_from_lakebase_table.py
@@ -18,7 +18,6 @@ from databricks.labs.dqx.rule_fingerprint import compute_rule_set_fingerprint_by
 from databricks.labs.dqx.config import InstallationChecksStorageConfig, LakebaseChecksStorageConfig
 from databricks.labs.dqx.engine import DQEngine
 from databricks.labs.dqx.checks_storage import LakebaseChecksStorageHandler
-from databricks.sdk import WorkspaceClient
 from databricks.sdk.errors import NotFound
 
 from tests.conftest import compare_checks
@@ -69,16 +68,6 @@ TEST_CHECKS = [
 ]
 
 
-def _is_orphan_to_sweep(
-    name: str, created: datetime | None, current_run_pattern: re.Pattern[str], grace_period: datetime
-) -> bool:
-    """Whether a resource is a sweepable orphan: matches the fixture naming, is not from the current
-    run, and is older than the grace period (younger ones may be in use by a concurrent run)."""
-    if current_run_pattern.match(name) or not _LAKEBASE_RESOURCE_PATTERN.match(name):
-        return False
-    return created is not None and created < grace_period
-
-
 def _safe_delete(delete: Callable[[], object], name: str, kind: str) -> None:
     """Best-effort delete: a single failure is logged and never blocks the rest of the sweep."""
     try:
@@ -89,13 +78,60 @@ def _safe_delete(delete: Callable[[], object], name: str, kind: str) -> None:
         logger.warning(f"Failed to delete orphaned Lakebase {kind} {name}: {e}")
 
 
+def _is_current_or_foreign(name: str, current_run_pattern: re.Pattern[str]) -> bool:
+    """True if the resource belongs to the current run or does not match the test fixture naming."""
+    return bool(current_run_pattern.match(name)) or not _LAKEBASE_RESOURCE_PATTERN.match(name)
+
+
+def _sweep_orphaned_catalogs(ws, current_run_pattern: re.Pattern[str], grace_period: datetime) -> None:
+    """Delete orphaned test catalogs. A catalog with no ``created_at`` is treated as orphaned and
+    deleted (it cannot be age-gated); the count is logged so we can see whether that path is hit."""
+    listed = matched = missing_created_at = attempted = 0
+    for catalog in ws.catalogs.list():
+        listed += 1
+        name = catalog.name or ""
+        if _is_current_or_foreign(name, current_run_pattern):
+            continue
+        matched += 1
+        created = datetime.fromtimestamp(catalog.created_at / 1000, tz=timezone.utc) if catalog.created_at else None
+        if created is None:
+            missing_created_at += 1
+        elif created >= grace_period:
+            continue
+        # catalogs.delete removes the UC catalog object (the metastore slot). These orphans have no
+        # surviving instance, so the database-catalog API cannot be used; force=True handles non-empty.
+        _safe_delete(partial(ws.catalogs.delete, name=name, force=True), name, "catalog")
+        attempted += 1
+    logger.info(
+        f"Lakebase catalog sweep: listed={listed} matched_naming={matched} "
+        f"missing_created_at={missing_created_at} delete_attempts={attempted}"
+    )
+
+
+def _sweep_orphaned_instances(ws, current_run_pattern: re.Pattern[str], grace_period: datetime) -> None:
+    """Delete orphaned test database instances older than the grace period."""
+    matched = attempted = 0
+    for instance in ws.database.list_database_instances():
+        name = instance.name or ""
+        if _is_current_or_foreign(name, current_run_pattern):
+            continue
+        matched += 1
+        if datetime.fromisoformat(instance.creation_time) >= grace_period:
+            continue
+        _safe_delete(partial(ws.database.delete_database_instance, name=name), name, "instance")
+        attempted += 1
+    logger.info(f"Lakebase instance sweep: matched_naming={matched} delete_attempts={attempted}")
+
+
 def _remove_orphaned_lakebase_resources(ws) -> None:
     """Delete orphaned Lakebase catalogs and instances left behind by cancelled CI runs.
 
     Orphaned resources accumulate when a github action is cancelled and the fixture cleanup process
     does not run. Database catalogs count toward the per-metastore catalog limit (1000) and are NOT
-    removed when their instance is deleted, so they are swept explicitly via the Unity Catalog API
-    (the database-catalog listing requires a still-existing instance, which orphans may lack).
+    removed when their instance is deleted, so they are swept explicitly. Catalogs are enumerated via
+    the Unity Catalog API (``ws.catalogs.list`` finds orphans whose instance is already gone, which
+    the per-instance database listing cannot) and deleted via the database catalog API, matching the
+    make_lakebase_instance fixture teardown.
 
     Runs only in CI. Resources for the current run, those not matching the fixture naming, and those
     younger than the 2h grace period (possibly in use by a concurrent run) are skipped.
@@ -108,35 +144,19 @@ def _remove_orphaned_lakebase_resources(ws) -> None:
     grace_period = datetime.now(timezone.utc) - timedelta(hours=2)  # aligned with tests timeout
 
     # Sweep orphaned catalogs first — these exhaust the metastore catalog limit and block new runs.
-    for catalog in ws.catalogs.list():
-        created = datetime.fromtimestamp(catalog.created_at / 1000, tz=timezone.utc) if catalog.created_at else None
-        if _is_orphan_to_sweep(catalog.name, created, current_run_pattern, grace_period):
-            _safe_delete(partial(ws.catalogs.delete, name=catalog.name, force=True), catalog.name, "catalog")
-
-    # Then sweep orphaned instances.
-    for instance in ws.database.list_database_instances():
-        created = datetime.fromisoformat(instance.creation_time)
-        if _is_orphan_to_sweep(instance.name, created, current_run_pattern, grace_period):
-            _safe_delete(partial(ws.database.delete_database_instance, name=instance.name), instance.name, "instance")
+    _sweep_orphaned_catalogs(ws, current_run_pattern, grace_period)
+    _sweep_orphaned_instances(ws, current_run_pattern, grace_period)
 
 
-@pytest.fixture(scope="session", autouse=True)
-def _sweep_orphaned_lakebase_resources():
-    """Sweep orphaned Lakebase resources once per worker session, before any test creates new ones.
+def test_remove_orphaned_lakebase_resources(ws):
+    """Maintenance sweep: remove orphaned Lakebase catalogs and instances left by cancelled CI runs.
 
-    Implemented as a session-scoped autouse fixture rather than a standalone test: with xdist
-    (``-n 10``) a single test runs on only one worker, leaving the other nine to hit the
-    already-exhausted metastore catalog limit. A session fixture runs once per worker ahead of that
-    worker's first Lakebase test, so the shared backlog is cleared before any ``make_lakebase_instance``
-    call. It builds its own client because the session scope cannot depend on the function-scoped
-    ``ws`` fixture; the sweep is gated to CI and only lists/deletes catalogs and instances.
+    Mirrors the established instance-cleanup test. Database catalogs count toward the per-metastore
+    catalog limit (1000) and are NOT removed when their instance is deleted, so they are swept
+    explicitly. Runs only in CI; resources for the current run, those not matching the fixture
+    naming, and those younger than the 2h grace period are skipped.
     """
-    if os.getenv("GITHUB_RUN_ID"):
-        try:
-            _remove_orphaned_lakebase_resources(WorkspaceClient())
-        except Exception as e:  # noqa: BLE001 — cleanup failure must never block the test suite
-            logger.warning(f"Orphaned Lakebase resource sweep failed: {e}")
-    yield
+    _remove_orphaned_lakebase_resources(ws)
 
 
 def test_load_checks_when_lakebase_table_does_not_exist(

--- a/tests/integration/test_save_and_load_checks_from_lakebase_table.py
+++ b/tests/integration/test_save_and_load_checks_from_lakebase_table.py
@@ -1,9 +1,12 @@
 import dataclasses
+import logging
 import os
 import re
 import time
+from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
+from functools import partial
 
 import pytest
 
@@ -15,9 +18,15 @@ from databricks.labs.dqx.rule_fingerprint import compute_rule_set_fingerprint_by
 from databricks.labs.dqx.config import InstallationChecksStorageConfig, LakebaseChecksStorageConfig
 from databricks.labs.dqx.engine import DQEngine
 from databricks.labs.dqx.checks_storage import LakebaseChecksStorageHandler
+from databricks.sdk import WorkspaceClient
 from databricks.sdk.errors import NotFound
 
 from tests.conftest import compare_checks
+
+logger = logging.getLogger(__name__)
+
+# Matches the resource names produced by the make_lakebase_instance fixture: dqx-test-<run_id>-<10 alnum>.
+_LAKEBASE_RESOURCE_PATTERN = re.compile(r"^dqx-test-\d+-[A-Za-z0-9]{10}$")
 
 
 TEST_CHECKS = [
@@ -60,33 +69,74 @@ TEST_CHECKS = [
 ]
 
 
-def test_remove_orphaned_lakebase_instances(ws):
-    """
-    Make sure all orphaned / leftover lakeabse instances are removed.
-    Orphaned instances are created when github action is cancelled and fixtures clean up process is not run.
+def _is_orphan_to_sweep(
+    name: str, created: datetime | None, current_run_pattern: re.Pattern[str], grace_period: datetime
+) -> bool:
+    """Whether a resource is a sweepable orphan: matches the fixture naming, is not from the current
+    run, and is older than the grace period (younger ones may be in use by a concurrent run)."""
+    if current_run_pattern.match(name) or not _LAKEBASE_RESOURCE_PATTERN.match(name):
+        return False
+    return created is not None and created < grace_period
+
+
+def _safe_delete(delete: Callable[[], object], name: str, kind: str) -> None:
+    """Best-effort delete: a single failure is logged and never blocks the rest of the sweep."""
+    try:
+        delete()
+    except NotFound:
+        pass
+    except Exception as e:  # noqa: BLE001 — best-effort sweep must not block the test run
+        logger.warning(f"Failed to delete orphaned Lakebase {kind} {name}: {e}")
+
+
+def _remove_orphaned_lakebase_resources(ws) -> None:
+    """Delete orphaned Lakebase catalogs and instances left behind by cancelled CI runs.
+
+    Orphaned resources accumulate when a github action is cancelled and the fixture cleanup process
+    does not run. Database catalogs count toward the per-metastore catalog limit (1000) and are NOT
+    removed when their instance is deleted, so they are swept explicitly via the Unity Catalog API
+    (the database-catalog listing requires a still-existing instance, which orphans may lack).
+
+    Runs only in CI. Resources for the current run, those not matching the fixture naming, and those
+    younger than the 2h grace period (possibly in use by a concurrent run) are skipped.
     """
     run_id = os.getenv("GITHUB_RUN_ID")
-
     if not run_id:
         return  # only applicable when run in CI
 
-    # must match pattern from make_lakebase_instance fixture
     current_run_pattern = re.compile(rf"^dqx-test-{run_id}-[A-Za-z0-9]+$")
-    pattern = re.compile(r"^dqx-test-\d+-[A-Za-z0-9]{10}$")
-
     grace_period = datetime.now(timezone.utc) - timedelta(hours=2)  # aligned with tests timeout
-    instances = []
-    for instance in ws.database.list_database_instances():
-        if current_run_pattern.match(instance.name):
-            continue  # skip as it belongs to the current run
-        if pattern.match(instance.name):
-            creation_time = datetime.fromisoformat(instance.creation_time)
-            # if database was created within the last 2h it maybe actively used by another test execution
-            if creation_time < grace_period:
-                instances.append(instance.name)
 
-    for instance in instances:
-        ws.database.delete_database_instance(name=instance)
+    # Sweep orphaned catalogs first — these exhaust the metastore catalog limit and block new runs.
+    for catalog in ws.catalogs.list():
+        created = datetime.fromtimestamp(catalog.created_at / 1000, tz=timezone.utc) if catalog.created_at else None
+        if _is_orphan_to_sweep(catalog.name, created, current_run_pattern, grace_period):
+            _safe_delete(partial(ws.catalogs.delete, name=catalog.name, force=True), catalog.name, "catalog")
+
+    # Then sweep orphaned instances.
+    for instance in ws.database.list_database_instances():
+        created = datetime.fromisoformat(instance.creation_time)
+        if _is_orphan_to_sweep(instance.name, created, current_run_pattern, grace_period):
+            _safe_delete(partial(ws.database.delete_database_instance, name=instance.name), instance.name, "instance")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _sweep_orphaned_lakebase_resources():
+    """Sweep orphaned Lakebase resources once per worker session, before any test creates new ones.
+
+    Implemented as a session-scoped autouse fixture rather than a standalone test: with xdist
+    (``-n 10``) a single test runs on only one worker, leaving the other nine to hit the
+    already-exhausted metastore catalog limit. A session fixture runs once per worker ahead of that
+    worker's first Lakebase test, so the shared backlog is cleared before any ``make_lakebase_instance``
+    call. It builds its own client because the session scope cannot depend on the function-scoped
+    ``ws`` fixture; the sweep is gated to CI and only lists/deletes catalogs and instances.
+    """
+    if os.getenv("GITHUB_RUN_ID"):
+        try:
+            _remove_orphaned_lakebase_resources(WorkspaceClient())
+        except Exception as e:  # noqa: BLE001 — cleanup failure must never block the test suite
+            logger.warning(f"Orphaned Lakebase resource sweep failed: {e}")
+    yield
 
 
 def test_load_checks_when_lakebase_table_does_not_exist(

--- a/tests/unit/test_llm_core.py
+++ b/tests/unit/test_llm_core.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 
 from databricks.labs.dqx.llm.llm_core import (
     DspyRuleGeneration,
+    DspyRuleGenerationWithSchemaInference,
     DspyRuleUsingDataStats,
     _filter_unsafe_sql_rules,
 )
@@ -15,32 +16,29 @@ def _make_mock_prediction(quality_rules: str) -> Mock:
     return pred
 
 
-# --- _filter_unsafe_sql_rules (pure-function tests, no mocks needed) ---
+# --- _filter_unsafe_sql_rules (pure-function tests — accepts pre-parsed list) ---
 
 
 def test_filter_unsafe_sql_rules_safe_query_kept():
     rules = [{"check": {"function": "sql_query", "arguments": {"query": "SELECT id, condition FROM {{ orders }}"}}}]
-    result = json.loads(_filter_unsafe_sql_rules(json.dumps(rules)))
+    result = _filter_unsafe_sql_rules(rules)
     assert len(result) == 1
     assert result[0]["check"]["arguments"]["query"] == "SELECT id, condition FROM {{ orders }}"
 
 
 def test_filter_unsafe_sql_rules_drops_drop_table():
     rules = [{"check": {"function": "sql_query", "arguments": {"query": "DROP TABLE orders"}}}]
-    result = json.loads(_filter_unsafe_sql_rules(json.dumps(rules)))
-    assert result == []
+    assert _filter_unsafe_sql_rules(rules) == []
 
 
 def test_filter_unsafe_sql_rules_drops_delete():
     rules = [{"check": {"function": "sql_query", "arguments": {"query": "DELETE FROM orders WHERE 1=1"}}}]
-    result = json.loads(_filter_unsafe_sql_rules(json.dumps(rules)))
-    assert result == []
+    assert _filter_unsafe_sql_rules(rules) == []
 
 
 def test_filter_unsafe_sql_rules_drops_insert():
     rules = [{"check": {"function": "sql_query", "arguments": {"query": "INSERT INTO bad VALUES (1)"}}}]
-    result = json.loads(_filter_unsafe_sql_rules(json.dumps(rules)))
-    assert result == []
+    assert _filter_unsafe_sql_rules(rules) == []
 
 
 def test_filter_unsafe_sql_rules_keeps_non_sql_query_rules():
@@ -48,7 +46,7 @@ def test_filter_unsafe_sql_rules_keeps_non_sql_query_rules():
         {"check": {"function": "is_not_null", "arguments": {"column": "id"}}},
         {"check": {"function": "sql_query", "arguments": {"query": "DELETE FROM orders WHERE 1=1"}}},
     ]
-    result = json.loads(_filter_unsafe_sql_rules(json.dumps(rules)))
+    result = _filter_unsafe_sql_rules(rules)
     assert len(result) == 1
     assert result[0]["check"]["function"] == "is_not_null"
 
@@ -58,23 +56,19 @@ def test_filter_unsafe_sql_rules_mixed_queries():
         {"check": {"function": "sql_query", "arguments": {"query": "SELECT id FROM {{ v }}"}}},
         {"check": {"function": "sql_query", "arguments": {"query": "TRUNCATE TABLE orders"}}},
     ]
-    result = json.loads(_filter_unsafe_sql_rules(json.dumps(rules)))
+    result = _filter_unsafe_sql_rules(rules)
     assert len(result) == 1
     assert "SELECT" in result[0]["check"]["arguments"]["query"]
 
 
-def test_filter_unsafe_sql_rules_invalid_json_passthrough():
-    bad_json = '[{"check": {"function": "sql_query"}'  # missing closing bracket
-    assert _filter_unsafe_sql_rules(bad_json) == bad_json
-
-
 def test_filter_unsafe_sql_rules_empty_array():
-    result = _filter_unsafe_sql_rules("[]")
-    assert json.loads(result) == []
+    assert _filter_unsafe_sql_rules([]) == []
 
 
-def test_filter_unsafe_sql_rules_non_array_json_returns_empty():
-    assert _filter_unsafe_sql_rules("null") == "[]"
+def test_filter_unsafe_sql_rules_non_list_returns_empty():
+    assert _filter_unsafe_sql_rules(None) == []
+    assert _filter_unsafe_sql_rules("not a list") == []
+    assert _filter_unsafe_sql_rules({"check": {}}) == []
 
 
 def test_filter_unsafe_sql_rules_skips_malformed_entries():
@@ -83,30 +77,47 @@ def test_filter_unsafe_sql_rules_skips_malformed_entries():
         {"check": "still not a rule"},
         {"check": {"function": "sql_query", "arguments": {"query": "SELECT 1 FROM {{ v }}"}}},
     ]
-    result = json.loads(_filter_unsafe_sql_rules(json.dumps(rules)))
+    result = _filter_unsafe_sql_rules(rules)
     assert len(result) == 1
     assert result[0]["check"]["function"] == "sql_query"
 
 
-def test_filter_unsafe_sql_rules_logs_warning(caplog):
+def test_filter_unsafe_sql_rules_drops_non_dict_arguments():
+    # arguments is a string — cannot extract query safely, rule is dropped
+    rules = [{"check": {"function": "sql_query", "arguments": "DROP TABLE x"}}]
+    assert _filter_unsafe_sql_rules(rules) == []
+
+
+def test_filter_unsafe_sql_rules_drops_non_string_query():
+    # query is an int — not a string, crash-safe, rule is dropped
+    rules = [{"check": {"function": "sql_query", "arguments": {"query": 123}}}]
+    assert _filter_unsafe_sql_rules(rules) == []
+
+
+def test_filter_unsafe_sql_rules_logs_warning_unsafe_sql(caplog):
     rules = [{"check": {"function": "sql_query", "arguments": {"query": "DROP TABLE secret"}}}]
     with caplog.at_level(logging.WARNING, logger="databricks.labs.dqx.llm.llm_core"):
-        _filter_unsafe_sql_rules(json.dumps(rules))
+        _filter_unsafe_sql_rules(rules)
     assert any("unsafe SQL query" in r.message for r in caplog.records)
 
 
-def test_filter_unsafe_sql_rules_null_query_kept():
-    # null query defaults to "" (safe); engine will reject it later via MissingParameterError
+def test_filter_unsafe_sql_rules_logs_warning_non_string_query(caplog):
+    rules = [{"check": {"function": "sql_query", "arguments": {"query": 123}}}]
+    with caplog.at_level(logging.WARNING, logger="databricks.labs.dqx.llm.llm_core"):
+        _filter_unsafe_sql_rules(rules)
+    assert any("non-string query argument" in r.message for r in caplog.records)
+
+
+def test_filter_unsafe_sql_rules_null_query_dropped():
+    # null query is not a string — dropped (not deferred)
     rules = [{"check": {"function": "sql_query", "arguments": {"query": None}}}]
-    result = json.loads(_filter_unsafe_sql_rules(json.dumps(rules)))
-    assert len(result) == 1
+    assert _filter_unsafe_sql_rules(rules) == []
 
 
-def test_filter_unsafe_sql_rules_missing_query_key_kept():
-    # missing "query" key also defaults to "" (safe); deferred to engine validation
+def test_filter_unsafe_sql_rules_missing_query_key_dropped():
+    # missing "query" key → arguments.get("query") returns None → not isinstance str → dropped
     rules = [{"check": {"function": "sql_query", "arguments": {}}}]
-    result = json.loads(_filter_unsafe_sql_rules(json.dumps(rules)))
-    assert len(result) == 1
+    assert _filter_unsafe_sql_rules(rules) == []
 
 
 # --- DspyRuleGeneration integration (mock generator) ---
@@ -148,6 +159,45 @@ def test_dspy_rule_generation_forward_invalid_json_returns_empty():
     assert result.quality_rules == "[]"
 
 
+def test_dspy_rule_generation_forward_empty_quality_rules_unchanged():
+    mock_gen = Mock()
+    mock_gen.return_value = _make_mock_prediction("")
+
+    module = DspyRuleGeneration(generator=mock_gen)
+    result = module.forward(schema_info="{}", business_description="test", available_functions="[]")
+
+    assert result.quality_rules == ""
+
+
+def test_dspy_rule_generation_forward_none_quality_rules_unchanged():
+    mock_gen = Mock()
+    pred = Mock()
+    pred.quality_rules = None
+    mock_gen.return_value = pred
+
+    module = DspyRuleGeneration(generator=mock_gen)
+    result = module.forward(schema_info="{}", business_description="test", available_functions="[]")
+
+    assert result.quality_rules is None
+
+
+# --- DspyRuleGenerationWithSchemaInference integration ---
+
+
+def test_dspy_rule_generation_with_schema_inference_forward_filters_unsafe_sql():
+    unsafe_rules = json.dumps([
+        {"check": {"function": "sql_query", "arguments": {"query": "DROP TABLE orders"}}}
+    ])
+    mock_gen = Mock()
+    mock_gen.return_value = _make_mock_prediction(unsafe_rules)
+
+    inner = DspyRuleGeneration(generator=mock_gen)
+    module = DspyRuleGenerationWithSchemaInference(generator=inner)
+    result = module.forward(schema_info="{}", business_description="test", available_functions="[]")
+
+    assert json.loads(result.quality_rules) == []
+
+
 # --- DspyRuleUsingDataStats integration (mock generator) ---
 
 
@@ -185,3 +235,25 @@ def test_dspy_rule_using_data_stats_forward_invalid_json_returns_empty():
     result = module.forward(data_summary_stats="{}", available_functions="[]")
 
     assert result.quality_rules == "[]"
+
+
+def test_dspy_rule_using_data_stats_forward_empty_quality_rules_unchanged():
+    mock_gen = Mock()
+    mock_gen.return_value = _make_mock_prediction("")
+
+    module = DspyRuleUsingDataStats(generator=mock_gen)
+    result = module.forward(data_summary_stats="{}", available_functions="[]")
+
+    assert result.quality_rules == ""
+
+
+def test_dspy_rule_using_data_stats_forward_none_quality_rules_unchanged():
+    mock_gen = Mock()
+    pred = Mock()
+    pred.quality_rules = None
+    mock_gen.return_value = pred
+
+    module = DspyRuleUsingDataStats(generator=mock_gen)
+    result = module.forward(data_summary_stats="{}", available_functions="[]")
+
+    assert result.quality_rules is None

--- a/tests/unit/test_llm_core.py
+++ b/tests/unit/test_llm_core.py
@@ -6,7 +6,6 @@ from databricks.labs.dqx.llm.llm_core import (
     DspyRuleGeneration,
     DspyRuleGenerationWithSchemaInference,
     DspyRuleUsingDataStats,
-    _filter_unsafe_sql_rules,
 )
 
 
@@ -16,117 +15,132 @@ def _make_mock_prediction(quality_rules: str) -> Mock:
     return pred
 
 
-# --- _filter_unsafe_sql_rules (pure-function tests — accepts pre-parsed list) ---
+def _filter_via_forward(quality_rules: str) -> list:
+    """Run the unsafe-SQL filtering through the public DspyRuleGeneration.forward() API.
+
+    The generator is mocked to return the given (JSON string) quality_rules; forward()
+    parses, filters and re-serializes them. Returns the parsed list of surviving rules.
+    """
+    mock_gen = Mock()
+    mock_gen.return_value = _make_mock_prediction(quality_rules)
+    module = DspyRuleGeneration(generator=mock_gen)
+    result = module.forward(schema_info="{}", business_description="test", available_functions="[]")
+    return json.loads(result.quality_rules)
 
 
-def test_filter_unsafe_sql_rules_safe_query_kept():
-    rules = [{"check": {"function": "sql_query", "arguments": {"query": "SELECT id, condition FROM {{ orders }}"}}}]
-    result = _filter_unsafe_sql_rules(rules)
+# --- unsafe sql_query filtering via the public forward() API ---
+
+
+def test_forward_keeps_safe_query():
+    rules = json.dumps(
+        [{"check": {"function": "sql_query", "arguments": {"query": "SELECT id, condition FROM {{ orders }}"}}}]
+    )
+    result = _filter_via_forward(rules)
     assert len(result) == 1
     assert result[0]["check"]["arguments"]["query"] == "SELECT id, condition FROM {{ orders }}"
 
 
-def test_filter_unsafe_sql_rules_drops_drop_table():
-    rules = [{"check": {"function": "sql_query", "arguments": {"query": "DROP TABLE orders"}}}]
-    assert _filter_unsafe_sql_rules(rules) == []
+def test_forward_drops_drop_table():
+    rules = json.dumps([{"check": {"function": "sql_query", "arguments": {"query": "DROP TABLE orders"}}}])
+    assert not _filter_via_forward(rules)
 
 
-def test_filter_unsafe_sql_rules_drops_delete():
-    rules = [{"check": {"function": "sql_query", "arguments": {"query": "DELETE FROM orders WHERE 1=1"}}}]
-    assert _filter_unsafe_sql_rules(rules) == []
+def test_forward_drops_delete():
+    rules = json.dumps([{"check": {"function": "sql_query", "arguments": {"query": "DELETE FROM orders WHERE 1=1"}}}])
+    assert not _filter_via_forward(rules)
 
 
-def test_filter_unsafe_sql_rules_drops_insert():
-    rules = [{"check": {"function": "sql_query", "arguments": {"query": "INSERT INTO bad VALUES (1)"}}}]
-    assert _filter_unsafe_sql_rules(rules) == []
+def test_forward_drops_insert():
+    rules = json.dumps([{"check": {"function": "sql_query", "arguments": {"query": "INSERT INTO bad VALUES (1)"}}}])
+    assert not _filter_via_forward(rules)
 
 
-def test_filter_unsafe_sql_rules_keeps_non_sql_query_rules():
-    rules = [
-        {"check": {"function": "is_not_null", "arguments": {"column": "id"}}},
-        {"check": {"function": "sql_query", "arguments": {"query": "DELETE FROM orders WHERE 1=1"}}},
-    ]
-    result = _filter_unsafe_sql_rules(rules)
+def test_forward_keeps_non_sql_query_rules():
+    rules = json.dumps(
+        [
+            {"check": {"function": "is_not_null", "arguments": {"column": "id"}}},
+            {"check": {"function": "sql_query", "arguments": {"query": "DELETE FROM orders WHERE 1=1"}}},
+        ]
+    )
+    result = _filter_via_forward(rules)
     assert len(result) == 1
     assert result[0]["check"]["function"] == "is_not_null"
 
 
-def test_filter_unsafe_sql_rules_mixed_queries():
-    rules = [
-        {"check": {"function": "sql_query", "arguments": {"query": "SELECT id FROM {{ v }}"}}},
-        {"check": {"function": "sql_query", "arguments": {"query": "TRUNCATE TABLE orders"}}},
-    ]
-    result = _filter_unsafe_sql_rules(rules)
+def test_forward_mixed_queries():
+    rules = json.dumps(
+        [
+            {"check": {"function": "sql_query", "arguments": {"query": "SELECT id FROM {{ v }}"}}},
+            {"check": {"function": "sql_query", "arguments": {"query": "TRUNCATE TABLE orders"}}},
+        ]
+    )
+    result = _filter_via_forward(rules)
     assert len(result) == 1
     assert "SELECT" in result[0]["check"]["arguments"]["query"]
 
 
-def test_filter_unsafe_sql_rules_empty_array():
-    assert _filter_unsafe_sql_rules([]) == []
+def test_forward_non_list_returns_empty():
+    assert not _filter_via_forward(json.dumps("not a list"))
+    assert not _filter_via_forward(json.dumps({"check": {}}))
+    assert not _filter_via_forward(json.dumps(None))
 
 
-def test_filter_unsafe_sql_rules_non_list_returns_empty():
-    assert _filter_unsafe_sql_rules(None) == []
-    assert _filter_unsafe_sql_rules("not a list") == []
-    assert _filter_unsafe_sql_rules({"check": {}}) == []
-
-
-def test_filter_unsafe_sql_rules_skips_malformed_entries():
-    rules = [
-        "not a rule",
-        {"check": "still not a rule"},
-        {"check": {"function": "sql_query", "arguments": {"query": "SELECT 1 FROM {{ v }}"}}},
-    ]
-    result = _filter_unsafe_sql_rules(rules)
+def test_forward_skips_malformed_entries():
+    rules = json.dumps(
+        [
+            "not a rule",
+            {"check": "still not a rule"},
+            {"check": {"function": "sql_query", "arguments": {"query": "SELECT 1 FROM {{ v }}"}}},
+        ]
+    )
+    result = _filter_via_forward(rules)
     assert len(result) == 1
     assert result[0]["check"]["function"] == "sql_query"
 
 
-def test_filter_unsafe_sql_rules_drops_non_dict_arguments():
+def test_forward_drops_non_dict_arguments():
     # arguments is a string — cannot extract query safely, rule is dropped
-    rules = [{"check": {"function": "sql_query", "arguments": "DROP TABLE x"}}]
-    assert _filter_unsafe_sql_rules(rules) == []
+    rules = json.dumps([{"check": {"function": "sql_query", "arguments": "DROP TABLE x"}}])
+    assert not _filter_via_forward(rules)
 
 
-def test_filter_unsafe_sql_rules_drops_non_string_query():
+def test_forward_drops_non_string_query():
     # query is an int — not a string, crash-safe, rule is dropped
-    rules = [{"check": {"function": "sql_query", "arguments": {"query": 123}}}]
-    assert _filter_unsafe_sql_rules(rules) == []
+    rules = json.dumps([{"check": {"function": "sql_query", "arguments": {"query": 123}}}])
+    assert not _filter_via_forward(rules)
 
 
-def test_filter_unsafe_sql_rules_logs_warning_unsafe_sql(caplog):
-    rules = [{"check": {"function": "sql_query", "arguments": {"query": "DROP TABLE secret"}}}]
+def test_forward_logs_warning_unsafe_sql(caplog):
+    rules = json.dumps([{"check": {"function": "sql_query", "arguments": {"query": "DROP TABLE secret"}}}])
     with caplog.at_level(logging.WARNING, logger="databricks.labs.dqx.llm.llm_core"):
-        _filter_unsafe_sql_rules(rules)
+        _filter_via_forward(rules)
     assert any("unsafe SQL query" in r.message for r in caplog.records)
 
 
-def test_filter_unsafe_sql_rules_logs_warning_non_string_query(caplog):
-    rules = [{"check": {"function": "sql_query", "arguments": {"query": 123}}}]
+def test_forward_logs_warning_non_string_query(caplog):
+    rules = json.dumps([{"check": {"function": "sql_query", "arguments": {"query": 123}}}])
     with caplog.at_level(logging.WARNING, logger="databricks.labs.dqx.llm.llm_core"):
-        _filter_unsafe_sql_rules(rules)
+        _filter_via_forward(rules)
     assert any("non-string query argument" in r.message for r in caplog.records)
 
 
-def test_filter_unsafe_sql_rules_null_query_dropped():
+def test_forward_null_query_dropped():
     # null query is not a string — dropped (not deferred)
-    rules = [{"check": {"function": "sql_query", "arguments": {"query": None}}}]
-    assert _filter_unsafe_sql_rules(rules) == []
+    rules = json.dumps([{"check": {"function": "sql_query", "arguments": {"query": None}}}])
+    assert not _filter_via_forward(rules)
 
 
-def test_filter_unsafe_sql_rules_missing_query_key_dropped():
+def test_forward_missing_query_key_dropped():
     # missing "query" key → arguments.get("query") returns None → not isinstance str → dropped
-    rules = [{"check": {"function": "sql_query", "arguments": {}}}]
-    assert _filter_unsafe_sql_rules(rules) == []
+    rules = json.dumps([{"check": {"function": "sql_query", "arguments": {}}}])
+    assert not _filter_via_forward(rules)
 
 
 # --- DspyRuleGeneration integration (mock generator) ---
 
 
 def test_dspy_rule_generation_forward_filters_unsafe_sql():
-    unsafe_rules = json.dumps([
-        {"check": {"function": "sql_query", "arguments": {"query": "DROP TABLE orders"}}}
-    ])
+    unsafe_rules = json.dumps([{"check": {"function": "sql_query", "arguments": {"query": "DROP TABLE orders"}}}])
     mock_gen = Mock()
     mock_gen.return_value = _make_mock_prediction(unsafe_rules)
 
@@ -137,9 +151,7 @@ def test_dspy_rule_generation_forward_filters_unsafe_sql():
 
 
 def test_dspy_rule_generation_forward_keeps_safe_sql():
-    safe_rules = json.dumps([
-        {"check": {"function": "sql_query", "arguments": {"query": "SELECT id FROM {{ v }}"}}}
-    ])
+    safe_rules = json.dumps([{"check": {"function": "sql_query", "arguments": {"query": "SELECT id FROM {{ v }}"}}}])
     mock_gen = Mock()
     mock_gen.return_value = _make_mock_prediction(safe_rules)
 
@@ -185,9 +197,7 @@ def test_dspy_rule_generation_forward_none_quality_rules_unchanged():
 
 
 def test_dspy_rule_generation_with_schema_inference_forward_filters_unsafe_sql():
-    unsafe_rules = json.dumps([
-        {"check": {"function": "sql_query", "arguments": {"query": "DROP TABLE orders"}}}
-    ])
+    unsafe_rules = json.dumps([{"check": {"function": "sql_query", "arguments": {"query": "DROP TABLE orders"}}}])
     mock_gen = Mock()
     mock_gen.return_value = _make_mock_prediction(unsafe_rules)
 
@@ -202,9 +212,9 @@ def test_dspy_rule_generation_with_schema_inference_forward_filters_unsafe_sql()
 
 
 def test_dspy_rule_using_data_stats_forward_filters_unsafe_sql():
-    unsafe_rules = json.dumps([
-        {"check": {"function": "sql_query", "arguments": {"query": "INSERT INTO bad VALUES (1)"}}}
-    ])
+    unsafe_rules = json.dumps(
+        [{"check": {"function": "sql_query", "arguments": {"query": "INSERT INTO bad VALUES (1)"}}}]
+    )
     mock_gen = Mock()
     mock_gen.return_value = _make_mock_prediction(unsafe_rules)
 
@@ -215,9 +225,7 @@ def test_dspy_rule_using_data_stats_forward_filters_unsafe_sql():
 
 
 def test_dspy_rule_using_data_stats_forward_keeps_safe_sql():
-    safe_rules = json.dumps([
-        {"check": {"function": "sql_query", "arguments": {"query": "SELECT id FROM {{ v }}"}}}
-    ])
+    safe_rules = json.dumps([{"check": {"function": "sql_query", "arguments": {"query": "SELECT id FROM {{ v }}"}}}])
     mock_gen = Mock()
     mock_gen.return_value = _make_mock_prediction(safe_rules)
 

--- a/tests/unit/test_llm_core.py
+++ b/tests/unit/test_llm_core.py
@@ -1,0 +1,187 @@
+import json
+import logging
+from unittest.mock import Mock
+
+from databricks.labs.dqx.llm.llm_core import (
+    DspyRuleGeneration,
+    DspyRuleUsingDataStats,
+    _filter_unsafe_sql_rules,
+)
+
+
+def _make_mock_prediction(quality_rules: str) -> Mock:
+    pred = Mock()
+    pred.quality_rules = quality_rules
+    return pred
+
+
+# --- _filter_unsafe_sql_rules (pure-function tests, no mocks needed) ---
+
+
+def test_filter_unsafe_sql_rules_safe_query_kept():
+    rules = [{"check": {"function": "sql_query", "arguments": {"query": "SELECT id, condition FROM {{ orders }}"}}}]
+    result = json.loads(_filter_unsafe_sql_rules(json.dumps(rules)))
+    assert len(result) == 1
+    assert result[0]["check"]["arguments"]["query"] == "SELECT id, condition FROM {{ orders }}"
+
+
+def test_filter_unsafe_sql_rules_drops_drop_table():
+    rules = [{"check": {"function": "sql_query", "arguments": {"query": "DROP TABLE orders"}}}]
+    result = json.loads(_filter_unsafe_sql_rules(json.dumps(rules)))
+    assert result == []
+
+
+def test_filter_unsafe_sql_rules_drops_delete():
+    rules = [{"check": {"function": "sql_query", "arguments": {"query": "DELETE FROM orders WHERE 1=1"}}}]
+    result = json.loads(_filter_unsafe_sql_rules(json.dumps(rules)))
+    assert result == []
+
+
+def test_filter_unsafe_sql_rules_drops_insert():
+    rules = [{"check": {"function": "sql_query", "arguments": {"query": "INSERT INTO bad VALUES (1)"}}}]
+    result = json.loads(_filter_unsafe_sql_rules(json.dumps(rules)))
+    assert result == []
+
+
+def test_filter_unsafe_sql_rules_keeps_non_sql_query_rules():
+    rules = [
+        {"check": {"function": "is_not_null", "arguments": {"column": "id"}}},
+        {"check": {"function": "sql_query", "arguments": {"query": "DELETE FROM orders WHERE 1=1"}}},
+    ]
+    result = json.loads(_filter_unsafe_sql_rules(json.dumps(rules)))
+    assert len(result) == 1
+    assert result[0]["check"]["function"] == "is_not_null"
+
+
+def test_filter_unsafe_sql_rules_mixed_queries():
+    rules = [
+        {"check": {"function": "sql_query", "arguments": {"query": "SELECT id FROM {{ v }}"}}},
+        {"check": {"function": "sql_query", "arguments": {"query": "TRUNCATE TABLE orders"}}},
+    ]
+    result = json.loads(_filter_unsafe_sql_rules(json.dumps(rules)))
+    assert len(result) == 1
+    assert "SELECT" in result[0]["check"]["arguments"]["query"]
+
+
+def test_filter_unsafe_sql_rules_invalid_json_passthrough():
+    bad_json = '[{"check": {"function": "sql_query"}'  # missing closing bracket
+    assert _filter_unsafe_sql_rules(bad_json) == bad_json
+
+
+def test_filter_unsafe_sql_rules_empty_array():
+    result = _filter_unsafe_sql_rules("[]")
+    assert json.loads(result) == []
+
+
+def test_filter_unsafe_sql_rules_non_array_json_returns_empty():
+    assert _filter_unsafe_sql_rules("null") == "[]"
+
+
+def test_filter_unsafe_sql_rules_skips_malformed_entries():
+    rules = [
+        "not a rule",
+        {"check": "still not a rule"},
+        {"check": {"function": "sql_query", "arguments": {"query": "SELECT 1 FROM {{ v }}"}}},
+    ]
+    result = json.loads(_filter_unsafe_sql_rules(json.dumps(rules)))
+    assert len(result) == 1
+    assert result[0]["check"]["function"] == "sql_query"
+
+
+def test_filter_unsafe_sql_rules_logs_warning(caplog):
+    rules = [{"check": {"function": "sql_query", "arguments": {"query": "DROP TABLE secret"}}}]
+    with caplog.at_level(logging.WARNING, logger="databricks.labs.dqx.llm.llm_core"):
+        _filter_unsafe_sql_rules(json.dumps(rules))
+    assert any("unsafe SQL query" in r.message for r in caplog.records)
+
+
+def test_filter_unsafe_sql_rules_null_query_kept():
+    # null query defaults to "" (safe); engine will reject it later via MissingParameterError
+    rules = [{"check": {"function": "sql_query", "arguments": {"query": None}}}]
+    result = json.loads(_filter_unsafe_sql_rules(json.dumps(rules)))
+    assert len(result) == 1
+
+
+def test_filter_unsafe_sql_rules_missing_query_key_kept():
+    # missing "query" key also defaults to "" (safe); deferred to engine validation
+    rules = [{"check": {"function": "sql_query", "arguments": {}}}]
+    result = json.loads(_filter_unsafe_sql_rules(json.dumps(rules)))
+    assert len(result) == 1
+
+
+# --- DspyRuleGeneration integration (mock generator) ---
+
+
+def test_dspy_rule_generation_forward_filters_unsafe_sql():
+    unsafe_rules = json.dumps([
+        {"check": {"function": "sql_query", "arguments": {"query": "DROP TABLE orders"}}}
+    ])
+    mock_gen = Mock()
+    mock_gen.return_value = _make_mock_prediction(unsafe_rules)
+
+    module = DspyRuleGeneration(generator=mock_gen)
+    result = module.forward(schema_info="{}", business_description="test", available_functions="[]")
+
+    assert json.loads(result.quality_rules) == []
+
+
+def test_dspy_rule_generation_forward_keeps_safe_sql():
+    safe_rules = json.dumps([
+        {"check": {"function": "sql_query", "arguments": {"query": "SELECT id FROM {{ v }}"}}}
+    ])
+    mock_gen = Mock()
+    mock_gen.return_value = _make_mock_prediction(safe_rules)
+
+    module = DspyRuleGeneration(generator=mock_gen)
+    result = module.forward(schema_info="{}", business_description="test", available_functions="[]")
+
+    assert len(json.loads(result.quality_rules)) == 1
+
+
+def test_dspy_rule_generation_forward_invalid_json_returns_empty():
+    mock_gen = Mock()
+    mock_gen.return_value = _make_mock_prediction("not json")
+
+    module = DspyRuleGeneration(generator=mock_gen)
+    result = module.forward(schema_info="{}", business_description="test", available_functions="[]")
+
+    assert result.quality_rules == "[]"
+
+
+# --- DspyRuleUsingDataStats integration (mock generator) ---
+
+
+def test_dspy_rule_using_data_stats_forward_filters_unsafe_sql():
+    unsafe_rules = json.dumps([
+        {"check": {"function": "sql_query", "arguments": {"query": "INSERT INTO bad VALUES (1)"}}}
+    ])
+    mock_gen = Mock()
+    mock_gen.return_value = _make_mock_prediction(unsafe_rules)
+
+    module = DspyRuleUsingDataStats(generator=mock_gen)
+    result = module.forward(data_summary_stats="{}", available_functions="[]")
+
+    assert json.loads(result.quality_rules) == []
+
+
+def test_dspy_rule_using_data_stats_forward_keeps_safe_sql():
+    safe_rules = json.dumps([
+        {"check": {"function": "sql_query", "arguments": {"query": "SELECT id FROM {{ v }}"}}}
+    ])
+    mock_gen = Mock()
+    mock_gen.return_value = _make_mock_prediction(safe_rules)
+
+    module = DspyRuleUsingDataStats(generator=mock_gen)
+    result = module.forward(data_summary_stats="{}", available_functions="[]")
+
+    assert len(json.loads(result.quality_rules)) == 1
+
+
+def test_dspy_rule_using_data_stats_forward_invalid_json_returns_empty():
+    mock_gen = Mock()
+    mock_gen.return_value = _make_mock_prediction("not json")
+
+    module = DspyRuleUsingDataStats(generator=mock_gen)
+    result = module.forward(data_summary_stats="{}", available_functions="[]")
+
+    assert result.quality_rules == "[]"

--- a/tests/unit/test_llm_utils.py
+++ b/tests/unit/test_llm_utils.py
@@ -8,6 +8,7 @@ from pyspark.sql.types import StructField, StringType, IntegerType
 
 from databricks.labs.dqx.check_funcs import make_condition, register_rule
 from databricks.labs.dqx.config import InputConfig
+from databricks.labs.dqx.rule import CHECK_FUNC_REGISTRY
 from databricks.labs.dqx.llm.llm_utils import (
     get_check_function_definitions,
     create_optimizer_training_set,
@@ -31,25 +32,25 @@ def test_get_check_function_definitions():
     custom_check_functions = {"dummy_custom_check_function_test": dummy_custom_check_function_test}
     result = list(
         filter(
-            lambda x: x['name'] == 'dummy_custom_check_function_test',
+            lambda x: x["name"] == "dummy_custom_check_function_test",
             get_check_function_definitions(custom_check_functions),
         )
     )
     sig = inspect.signature(dummy_custom_check_function_test)
     assert result[0] == {
-        'name': 'dummy_custom_check_function_test',
-        'type': 'row',
-        'doc': 'Test the custom check function.',
-        'signature': str(sig),
-        'parameters': str(sig.parameters),
-        'implementation': '@register_rule("row")\ndef dummy_custom_check_function_test(column: str, suffix: str):\n    """\n    Test the custom check function.\n    """\n    return make_condition(\n        F.col(column).endswith(suffix), f"Column {column} ends with {suffix}", f"{column}_ends_with_{suffix}"\n    )\n',
+        "name": "dummy_custom_check_function_test",
+        "type": "row",
+        "doc": "Test the custom check function.",
+        "signature": str(sig),
+        "parameters": str(sig.parameters),
+        "implementation": '@register_rule("row")\ndef dummy_custom_check_function_test(column: str, suffix: str):\n    """\n    Test the custom check function.\n    """\n    return make_condition(\n        F.col(column).endswith(suffix), f"Column {column} ends with {suffix}", f"{column}_ends_with_{suffix}"\n    )\n',
     }
 
 
 def test_get_check_function_definitions_with_missing_custom_check_functions():
     result = list(
         filter(
-            lambda x: x['name'] == 'dummy_custom_check_function_test',
+            lambda x: x["name"] == "dummy_custom_check_function_test",
             get_check_function_definitions(),
         )
     )
@@ -62,7 +63,7 @@ def test_get_check_function_definitions_with_custom_check_functions_missing_spec
 
     result = list(
         filter(
-            lambda x: x['name'] == 'dummy_custom_check_function_test',
+            lambda x: x["name"] == "dummy_custom_check_function_test",
             get_check_function_definitions(custom_check_functions),
         )
     )
@@ -74,21 +75,21 @@ def test_get_required_check_function_definitions():
 
     result = list(
         filter(
-            lambda x: x['check_function_name'] == 'dummy_custom_check_function_test',
+            lambda x: x["check_function_name"] == "dummy_custom_check_function_test",
             get_required_check_functions_definitions(custom_check_functions),
         )
     )
     sig = inspect.signature(dummy_custom_check_function_test)
     assert result[0] == {
-        'check_function_name': 'dummy_custom_check_function_test',
-        'parameters': str(sig.parameters),
+        "check_function_name": "dummy_custom_check_function_test",
+        "parameters": str(sig.parameters),
     }
 
 
 def test_get_required_check_functions_definitions_with_missing_custom_check_functions():
     result = list(
         filter(
-            lambda x: x['check_function_name'] == 'dummy_custom_check_function_test',
+            lambda x: x["check_function_name"] == "dummy_custom_check_function_test",
             get_required_check_functions_definitions(),
         )
     )
@@ -101,7 +102,7 @@ def test_get_required_check_function_definition_with_custom_check_functions_miss
 
     result = list(
         filter(
-            lambda x: x['check_function_name'] == 'dummy_custom_check_function_test',
+            lambda x: x["check_function_name"] == "dummy_custom_check_function_test",
             get_required_check_functions_definitions(custom_check_functions),
         )
     )
@@ -124,11 +125,11 @@ def test_get_training_examples():
         assert isinstance(example, dspy.Example)
 
         # Verify required attributes exist
-        assert hasattr(example, 'schema_info')
-        assert hasattr(example, 'business_description')
-        assert hasattr(example, 'available_functions')
-        assert hasattr(example, 'quality_rules')
-        assert hasattr(example, 'reasoning')
+        assert hasattr(example, "schema_info")
+        assert hasattr(example, "business_description")
+        assert hasattr(example, "available_functions")
+        assert hasattr(example, "quality_rules")
+        assert hasattr(example, "reasoning")
 
         schema_info = json.loads(example.schema_info)
         assert isinstance(schema_info, dict)
@@ -155,6 +156,25 @@ def test_get_training_examples_with_custom_check_functions():
         )
     ]
     assert filtered_examples
+
+
+@pytest.mark.parametrize(
+    "training_set_factory",
+    [create_optimizer_training_set, create_optimizer_training_set_with_stats],
+)
+def test_training_examples_reference_only_registered_functions(training_set_factory):
+    """Every function name used in the few-shot training examples must resolve in the registry.
+
+    Guards against typos like ``is_email`` (should be ``is_valid_email``): an unregistered
+    name silently teaches the LLM to emit rules that get dropped by validation at generation time.
+    """
+    referenced_functions = set()
+    for example in training_set_factory():
+        for rule in json.loads(example.quality_rules):
+            referenced_functions.add(rule["check"]["function"])
+
+    unknown_functions = referenced_functions - set(CHECK_FUNC_REGISTRY)
+    assert not unknown_functions, f"Training examples reference unregistered check functions: {unknown_functions}"
 
 
 @pytest.mark.parametrize(
@@ -206,11 +226,11 @@ def test_create_optimizer_training_set_with_stats():
         assert isinstance(example, dspy.Example)
 
         # Verify required attributes exist
-        assert hasattr(example, 'business_description')
-        assert hasattr(example, 'data_summary_stats')
-        assert hasattr(example, 'available_functions')
-        assert hasattr(example, 'quality_rules')
-        assert hasattr(example, 'reasoning')
+        assert hasattr(example, "business_description")
+        assert hasattr(example, "data_summary_stats")
+        assert hasattr(example, "available_functions")
+        assert hasattr(example, "quality_rules")
+        assert hasattr(example, "reasoning")
 
         # Verify data_summary_stats is valid JSON
         data_summary_stats = json.loads(example.data_summary_stats)


### PR DESCRIPTION
## Changes

adds SQL safety validation to both LLM-assisted rule generation paths so that any `sql_query` rule containing unsafe SQL (DML/DDL) is dropped before being returned to the caller.

- added `_filter_unsafe_sql_rules()` in `llm/llm_core.py` : parses the generated JSON rules array and drops any rule whose `check.function` is `sql_query` and whose `query` argument fails `is_sql_query_safe()`, logging a warning with the sanitized query string (CWE-117)
- hooked it into `DspyRuleGeneration.forward()` and `DspyRuleUsingDataStats.forward()` via an `else` clause on the existing JSON-validation block; `DspyRuleGenerationWithSchemaInference` inherits the fix automatically since it delegates to `DspyRuleGeneration`
> note: `max_tokens` was already present in `LLMModelConfig` and forwarded to `dspy.LM()`, it caps completion length, not prompt input, which is sufficient for the issue's intent of bounding unbounded LLM output.
- fixed training example for ai-assisted rules generation


### Linked issues

resolves #1123

### Tests

- [ ] manually tested
- [x] added unit tests
- [ ] added integration tests
- [ ] added end-to-end tests
- [ ] added performance tests

19 unit tests in `tests/unit/test_llm_core.py` covering: safe SELECT queries pass through, unsafe DROP/DELETE/INSERT/TRUNCATE rules are dropped, non-`sql_query` rules are unaffected, mixed safe+unsafe batches, null/missing `query` argument, non-array JSON input, malformed rule entries, invalid JSON passthrough, and warning log emission.

### Documentation and Demos

- [ ] added/updated demos
- [ ] added/updated docs
- [ ] added/updated agent skills
