### PR TITLE
Added databricks runtime requirements verification

### DIFF
--- a/src/databricks/labs/dqx/engine.py
+++ b/src/databricks/labs/dqx/engine.py
@@ -11,6 +11,7 @@ from typing import Any
 from uuid import uuid4
 
 import pyspark.sql.functions as F
+from pyspark.errors import AnalysisException
 from pyspark.sql import DataFrame, Observation, SparkSession
 from pyspark.sql.streaming import StreamingQuery
 
@@ -40,6 +41,7 @@ from databricks.labs.dqx.manager import DQRuleManager
 from databricks.labs.dqx.reporting_columns import ColumnArguments, DefaultColumnNames, merge_info_columns
 from databricks.labs.dqx.rule import (
     Criticality,
+    CHECK_FUNC_DBR_VERSION_REQUIREMENT_ATTRIBUTE,
     DQRule,
     CHECK_FUNC_REGISTRY_ORIGINAL_COLUMNS_PRESELECTION,
 )
@@ -143,6 +145,8 @@ class DQEngineCore(DQEngineCoreBase):
             raise InvalidCheckError(
                 "All elements in the 'checks' list must be instances of DQRule. Use 'apply_checks_by_metadata' to pass checks as list of dicts instead."
             )
+
+        self._validate_dbr_version_requirements(checks)
 
         warning_checks = self._get_check_columns(checks, Criticality.WARN.value)
         error_checks = self._get_check_columns(checks, Criticality.ERROR.value)
@@ -390,6 +394,49 @@ class DQEngineCore(DQEngineCoreBase):
     def _all_are_dq_rules(checks: list[DQRule]) -> bool:
         """Check if all elements in the checks list are instances of DQRule."""
         return all(isinstance(check, DQRule) for check in checks)
+
+    def _validate_dbr_version_requirements(self, checks: list[DQRule]) -> None:
+        """Raise InvalidParameterError if the current DBR major version is below the highest version required by any check.
+
+        The requirement is declared by decorating a check function with *requires_dbr_version(major_version)*.
+        The current DBR version is resolved via *current_version().dbr_version* Spark SQL function.
+        Validation checks that the current major version is >= the required major version (not an exact match).
+
+        Args:
+            checks: List of DQRule instances to validate.
+
+        Raises:
+            InvalidCheckError: If the current DBR major version is below the maximum required version,
+                or if the DBR version cannot be resolved (non-Databricks environment or null result).
+        """
+        versioned = {
+            c.check_func.__name__: getattr(c.check_func, CHECK_FUNC_DBR_VERSION_REQUIREMENT_ATTRIBUTE)
+            for c in checks
+            if getattr(c.check_func, CHECK_FUNC_DBR_VERSION_REQUIREMENT_ATTRIBUTE, None) is not None
+        }
+        if not versioned:
+            return
+        required = max(versioned.values())
+        try:
+            rows = self.spark.sql("select current_version().dbr_version as dbr_version").collect()
+            dbr_version_str = rows[0]["dbr_version"] if rows else None
+        except AnalysisException as e:
+            raise InvalidCheckError(
+                "Check functions with a DBR version requirement can only run on Databricks Runtime. "
+                f"Failed to resolve the current DBR version: {e}"
+            ) from e
+        if dbr_version_str is None:
+            raise InvalidCheckError(
+                "Check functions with a DBR version requirement can only run on Databricks Runtime. "
+                "current_version().dbr_version returned null."
+            )
+        major = int(dbr_version_str.split(".")[0])
+        if major < required:
+            check_names = ", ".join(sorted(versioned))
+            raise InvalidCheckError(
+                f"Check functions [{check_names}] require Databricks Runtime >= {required}, "
+                f"but the current version is {dbr_version_str} (major: {major})."
+            )
 
     def _preselect_original_columns(self, df: DataFrame, check: DQRule) -> DQRule:
         """

--- a/src/databricks/labs/dqx/engine.py
+++ b/src/databricks/labs/dqx/engine.py
@@ -2,6 +2,7 @@ import copy
 import inspect
 import logging
 import os
+import re
 from concurrent import futures
 from collections.abc import Callable
 from dataclasses import replace
@@ -396,18 +397,23 @@ class DQEngineCore(DQEngineCoreBase):
         return all(isinstance(check, DQRule) for check in checks)
 
     def _validate_dbr_version_requirements(self, checks: list[DQRule]) -> None:
-        """Raise InvalidCheckError if the current DBR major version is below the highest version required by any check.
+        """Raise InvalidCheckError if the current Databricks Runtime version is below the version required by any check.
 
-        The requirement is declared by decorating a check function with *requires_dbr_version(major_version)*.
-        The current DBR version is resolved via *current_version().dbr_version* Spark SQL function.
-        Validation checks that the current major version is >= the required major version (not an exact match).
+        The requirement is declared by decorating a check function with *requires_dbr_version("major.minor")*.
+        The current DBR version is resolved via the *current_version().dbr_version* Spark SQL function and compared
+        as a *(major, minor)* tuple. The version string may carry a suffix (for example *"18.2.x-photon-scala2.13"*
+        on serverless or *"15.4 LTS"*); only the leading *major.minor* is used.
+
+        When the version cannot be determined - *current_version().dbr_version* returns null or empty - the
+        requirement is not enforced rather than blocking an environment that may well support the check.
 
         Args:
             checks: List of DQRule instances to validate.
 
         Raises:
-            InvalidCheckError: If the current DBR major version is below the maximum required version,
-                or if the DBR version cannot be resolved (non-Databricks environment or null result).
+            InvalidCheckError: If the current DBR version is below the maximum required version, if the
+                *current_version()* function is unavailable (non-Databricks environment), or if a non-empty
+                version string has no leading *major.minor* and cannot be parsed.
         """
         versioned = {
             c.check_func.__name__: getattr(c.check_func, CHECK_FUNC_MIN_DBR_VERSION_ATTRIBUTE)
@@ -428,17 +434,17 @@ class DQEngineCore(DQEngineCoreBase):
                 f"Failed to resolve the current DBR version: {e}"
             ) from e
 
-        if dbr_version_str is None:
-            raise InvalidCheckError(
-                "Check functions with a DBR version requirement can only run on Databricks Runtime. "
-                "current_version().dbr_version returned null."
-            )
+        # When the version cannot be determined (null or empty), skip enforcement rather than blocking an
+        # environment that may well support the check.
+        if dbr_version_str is None or not dbr_version_str.strip():
+            return
 
-        parts = dbr_version_str.split(".")
-        try:
-            current = (int(parts[0]), int(parts[1]) if len(parts) > 1 else 0)
-        except (ValueError, IndexError) as e:
-            raise InvalidCheckError(f"Cannot parse Databricks Runtime version: '{dbr_version_str}'.") from e
+        # Resolve the leading "major.minor" prefix, tolerating suffixes such as "18.2.x-photon-scala2.13"
+        # (serverless) or "15.4 LTS".
+        match = re.match(r"\s*(\d+)\.(\d+)", dbr_version_str)
+        if match is None:
+            raise InvalidCheckError(f"Cannot parse Databricks Runtime version: '{dbr_version_str}'.")
+        current = (int(match.group(1)), int(match.group(2)))
 
         if current < required:
             check_names = ", ".join(sorted(versioned))

--- a/src/databricks/labs/dqx/engine.py
+++ b/src/databricks/labs/dqx/engine.py
@@ -41,7 +41,7 @@ from databricks.labs.dqx.manager import DQRuleManager
 from databricks.labs.dqx.reporting_columns import ColumnArguments, DefaultColumnNames, merge_info_columns
 from databricks.labs.dqx.rule import (
     Criticality,
-    CHECK_FUNC_DBR_VERSION_REQUIREMENT_ATTRIBUTE,
+    CHECK_FUNC_MIN_DBR_VERSION_ATTRIBUTE,
     DQRule,
     CHECK_FUNC_REGISTRY_ORIGINAL_COLUMNS_PRESELECTION,
 )
@@ -396,7 +396,7 @@ class DQEngineCore(DQEngineCoreBase):
         return all(isinstance(check, DQRule) for check in checks)
 
     def _validate_dbr_version_requirements(self, checks: list[DQRule]) -> None:
-        """Raise InvalidParameterError if the current DBR major version is below the highest version required by any check.
+        """Raise InvalidCheckError if the current DBR major version is below the highest version required by any check.
 
         The requirement is declared by decorating a check function with *requires_dbr_version(major_version)*.
         The current DBR version is resolved via *current_version().dbr_version* Spark SQL function.
@@ -410,12 +410,14 @@ class DQEngineCore(DQEngineCoreBase):
                 or if the DBR version cannot be resolved (non-Databricks environment or null result).
         """
         versioned = {
-            c.check_func.__name__: getattr(c.check_func, CHECK_FUNC_DBR_VERSION_REQUIREMENT_ATTRIBUTE)
+            c.check_func.__name__: getattr(c.check_func, CHECK_FUNC_MIN_DBR_VERSION_ATTRIBUTE)
             for c in checks
-            if getattr(c.check_func, CHECK_FUNC_DBR_VERSION_REQUIREMENT_ATTRIBUTE, None) is not None
+            if getattr(c.check_func, CHECK_FUNC_MIN_DBR_VERSION_ATTRIBUTE, None) is not None
         }
+
         if not versioned:
             return
+
         required = max(versioned.values())
         try:
             rows = self.spark.sql("select current_version().dbr_version as dbr_version").collect()
@@ -425,17 +427,25 @@ class DQEngineCore(DQEngineCoreBase):
                 "Check functions with a DBR version requirement can only run on Databricks Runtime. "
                 f"Failed to resolve the current DBR version: {e}"
             ) from e
+
         if dbr_version_str is None:
             raise InvalidCheckError(
                 "Check functions with a DBR version requirement can only run on Databricks Runtime. "
                 "current_version().dbr_version returned null."
             )
-        major = int(dbr_version_str.split(".")[0])
-        if major < required:
+
+        parts = dbr_version_str.split(".")
+        try:
+            current = (int(parts[0]), int(parts[1]) if len(parts) > 1 else 0)
+        except (ValueError, IndexError) as e:
+            raise InvalidCheckError(f"Cannot parse Databricks Runtime version: '{dbr_version_str}'.") from e
+
+        if current < required:
             check_names = ", ".join(sorted(versioned))
+            required_str = f"{required[0]}.{required[1]}"
             raise InvalidCheckError(
-                f"Check functions [{check_names}] require Databricks Runtime >= {required}, "
-                f"but the current version is {dbr_version_str} (major: {major})."
+                f"Check functions [{check_names}] require Databricks Runtime >= {required_str}, "
+                f"but the current version is {dbr_version_str}."
             )
 
     def _preselect_original_columns(self, df: DataFrame, check: DQRule) -> DQRule:

--- a/src/databricks/labs/dqx/geo/check_funcs.py
+++ b/src/databricks/labs/dqx/geo/check_funcs.py
@@ -6,7 +6,7 @@ from typing import Literal
 from pyspark.sql import Column, DataFrame
 import pyspark.sql.functions as F
 
-from databricks.labs.dqx.rule import register_rule
+from databricks.labs.dqx.rule import register_rule, requires_dbr_version
 from databricks.labs.dqx.check_funcs import make_condition, get_normalized_column_and_expr, get_limit_expr
 from databricks.labs.dqx.errors import InvalidParameterError
 
@@ -104,6 +104,7 @@ def is_longitude(column: str | Column) -> Column:
     )
 
 
+@requires_dbr_version(17)
 @register_rule("row")
 def is_geometry(column: str | Column) -> Column:
     """Checks whether the values in the input column are valid geometries.
@@ -131,6 +132,7 @@ def is_geometry(column: str | Column) -> Column:
     )
 
 
+@requires_dbr_version(17)
 @register_rule("row")
 def is_geography(column: str | Column) -> Column:
     """Checks whether the values in the input column are valid geographies.
@@ -158,6 +160,7 @@ def is_geography(column: str | Column) -> Column:
     )
 
 
+@requires_dbr_version(17)
 @register_rule("row")
 def is_point(column: str | Column) -> Column:
     """Checks whether the values in the input column are point geometries.
@@ -185,6 +188,7 @@ def is_point(column: str | Column) -> Column:
     )
 
 
+@requires_dbr_version(17)
 @register_rule("row")
 def is_linestring(column: str | Column) -> Column:
     """Checks whether the values in the input column are linestring geometries.
@@ -212,6 +216,7 @@ def is_linestring(column: str | Column) -> Column:
     )
 
 
+@requires_dbr_version(17)
 @register_rule("row")
 def is_polygon(column: str | Column) -> Column:
     """Checks whether the values in the input column are polygon geometries.
@@ -239,6 +244,7 @@ def is_polygon(column: str | Column) -> Column:
     )
 
 
+@requires_dbr_version(17)
 @register_rule("row")
 def is_multipoint(column: str | Column) -> Column:
     """Checks whether the values in the input column are multipoint geometries.
@@ -266,6 +272,7 @@ def is_multipoint(column: str | Column) -> Column:
     )
 
 
+@requires_dbr_version(17)
 @register_rule("row")
 def is_multilinestring(column: str | Column) -> Column:
     """Checks whether the values in the input column are multilinestring geometries.
@@ -293,6 +300,7 @@ def is_multilinestring(column: str | Column) -> Column:
     )
 
 
+@requires_dbr_version(17)
 @register_rule("row")
 def is_multipolygon(column: str | Column) -> Column:
     """Checks whether the values in the input column are multipolygon geometries.
@@ -347,6 +355,7 @@ def is_geometrycollection(column: str | Column) -> Column:
     )
 
 
+@requires_dbr_version(17)
 @register_rule("row")
 def is_ogc_valid(column: str | Column) -> Column:
     """Checks whether the values in the input column are valid geometries in the OGC sense.
@@ -375,6 +384,7 @@ def is_ogc_valid(column: str | Column) -> Column:
     )
 
 
+@requires_dbr_version(17)
 @register_rule("row")
 def is_non_empty_geometry(column: str | Column) -> Column:
     """Checks whether the values in the input column are empty geometries.
@@ -403,6 +413,7 @@ def is_non_empty_geometry(column: str | Column) -> Column:
     )
 
 
+@requires_dbr_version(17)
 @register_rule("row")
 def is_not_null_island(column: str | Column) -> Column:
     """Checks whether the values in the input column are NULL island geometries (e.g. POINT(0 0), POINTZ(0 0 0), or
@@ -439,6 +450,7 @@ def is_not_null_island(column: str | Column) -> Column:
     )
 
 
+@requires_dbr_version(17)
 @register_rule("row")
 def has_dimension(column: str | Column, dimension: int) -> Column:
     """Checks whether the geometries/geographies in the input column have a given dimension.
@@ -468,6 +480,7 @@ def has_dimension(column: str | Column, dimension: int) -> Column:
     )
 
 
+@requires_dbr_version(17)
 @register_rule("row")
 def has_x_coordinate_between(column: str | Column, min_value: float, max_value: float) -> Column:
     """Checks whether the x coordinates of the geometries in the input column are between a given range.
@@ -500,6 +513,7 @@ def has_x_coordinate_between(column: str | Column, min_value: float, max_value: 
     )
 
 
+@requires_dbr_version(17)
 @register_rule("row")
 def has_y_coordinate_between(column: str | Column, min_value: float, max_value: float) -> Column:
     """Checks whether the y coordinates of the geometries in the input column are between a given range.
@@ -532,6 +546,7 @@ def has_y_coordinate_between(column: str | Column, min_value: float, max_value: 
     )
 
 
+@requires_dbr_version(17)
 @register_rule("row")
 def is_area_equal_to(
     column: str | Column, value: int | float | str | Column, srid: int | None = 3857, geodesic: bool = False
@@ -569,6 +584,7 @@ def is_area_equal_to(
     )
 
 
+@requires_dbr_version(17)
 @register_rule("row")
 def is_area_not_equal_to(
     column: str | Column, value: int | float | str | Column, srid: int | None = 3857, geodesic: bool = False
@@ -606,6 +622,7 @@ def is_area_not_equal_to(
     )
 
 
+@requires_dbr_version(17)
 @register_rule("row")
 def is_area_not_greater_than(
     column: str | Column, value: int | float | str | Column, srid: int | None = 3857, geodesic: bool = False
@@ -643,6 +660,7 @@ def is_area_not_greater_than(
     )
 
 
+@requires_dbr_version(17)
 @register_rule("row")
 def is_area_not_less_than(
     column: str | Column, value: int | float | str | Column, srid: int | None = 3857, geodesic: bool = False
@@ -680,6 +698,7 @@ def is_area_not_less_than(
     )
 
 
+@requires_dbr_version(17)
 @register_rule("row")
 def is_num_points_equal_to(column: str | Column, value: int | float | str | Column) -> Column:
     """
@@ -708,6 +727,7 @@ def is_num_points_equal_to(column: str | Column, value: int | float | str | Colu
     )
 
 
+@requires_dbr_version(17)
 @register_rule("row")
 def is_num_points_not_equal_to(column: str | Column, value: int | float | str | Column) -> Column:
     """
@@ -736,6 +756,7 @@ def is_num_points_not_equal_to(column: str | Column, value: int | float | str | 
     )
 
 
+@requires_dbr_version(17)
 @register_rule("row")
 def is_num_points_not_greater_than(column: str | Column, value: int | float | str | Column) -> Column:
     """
@@ -764,6 +785,7 @@ def is_num_points_not_greater_than(column: str | Column, value: int | float | st
     )
 
 
+@requires_dbr_version(17)
 @register_rule("row")
 def is_num_points_not_less_than(column: str | Column, value: int | float | str | Column) -> Column:
     """
@@ -864,6 +886,7 @@ def _compare_spatial_sql_function_result(
     )
 
 
+@requires_dbr_version(17)
 @register_rule("dataset")
 def are_polygons_mutually_disjoint(
     column: str | Column,
@@ -1228,6 +1251,7 @@ def is_geo_intersects(
     return _has_topological_relationship_approximate(column, reference_geometry, resolution, "INTERSECTS")
 
 
+@requires_dbr_version(17)
 @register_rule("row")
 def is_geo_touches(
     column: str | Column,
@@ -1268,6 +1292,7 @@ def is_geo_touches(
     )
 
 
+@requires_dbr_version(17)
 @register_rule("row")
 def is_geo_within(
     column: str | Column,

--- a/src/databricks/labs/dqx/geo/check_funcs.py
+++ b/src/databricks/labs/dqx/geo/check_funcs.py
@@ -104,7 +104,7 @@ def is_longitude(column: str | Column) -> Column:
     )
 
 
-@requires_dbr_version(17)
+@requires_dbr_version("17.1")
 @register_rule("row")
 def is_geometry(column: str | Column) -> Column:
     """Checks whether the values in the input column are valid geometries.
@@ -132,7 +132,7 @@ def is_geometry(column: str | Column) -> Column:
     )
 
 
-@requires_dbr_version(17)
+@requires_dbr_version("17.1")
 @register_rule("row")
 def is_geography(column: str | Column) -> Column:
     """Checks whether the values in the input column are valid geographies.
@@ -160,7 +160,7 @@ def is_geography(column: str | Column) -> Column:
     )
 
 
-@requires_dbr_version(17)
+@requires_dbr_version("17.1")
 @register_rule("row")
 def is_point(column: str | Column) -> Column:
     """Checks whether the values in the input column are point geometries.
@@ -188,7 +188,7 @@ def is_point(column: str | Column) -> Column:
     )
 
 
-@requires_dbr_version(17)
+@requires_dbr_version("17.1")
 @register_rule("row")
 def is_linestring(column: str | Column) -> Column:
     """Checks whether the values in the input column are linestring geometries.
@@ -216,7 +216,7 @@ def is_linestring(column: str | Column) -> Column:
     )
 
 
-@requires_dbr_version(17)
+@requires_dbr_version("17.1")
 @register_rule("row")
 def is_polygon(column: str | Column) -> Column:
     """Checks whether the values in the input column are polygon geometries.
@@ -244,7 +244,7 @@ def is_polygon(column: str | Column) -> Column:
     )
 
 
-@requires_dbr_version(17)
+@requires_dbr_version("17.1")
 @register_rule("row")
 def is_multipoint(column: str | Column) -> Column:
     """Checks whether the values in the input column are multipoint geometries.
@@ -272,7 +272,7 @@ def is_multipoint(column: str | Column) -> Column:
     )
 
 
-@requires_dbr_version(17)
+@requires_dbr_version("17.1")
 @register_rule("row")
 def is_multilinestring(column: str | Column) -> Column:
     """Checks whether the values in the input column are multilinestring geometries.
@@ -300,7 +300,7 @@ def is_multilinestring(column: str | Column) -> Column:
     )
 
 
-@requires_dbr_version(17)
+@requires_dbr_version("17.1")
 @register_rule("row")
 def is_multipolygon(column: str | Column) -> Column:
     """Checks whether the values in the input column are multipolygon geometries.
@@ -328,6 +328,7 @@ def is_multipolygon(column: str | Column) -> Column:
     )
 
 
+@requires_dbr_version("17.1")
 @register_rule("row")
 def is_geometrycollection(column: str | Column) -> Column:
     """Checks whether the values in the input column are geometrycollection geometries.
@@ -355,7 +356,7 @@ def is_geometrycollection(column: str | Column) -> Column:
     )
 
 
-@requires_dbr_version(17)
+@requires_dbr_version("17.1")
 @register_rule("row")
 def is_ogc_valid(column: str | Column) -> Column:
     """Checks whether the values in the input column are valid geometries in the OGC sense.
@@ -384,7 +385,7 @@ def is_ogc_valid(column: str | Column) -> Column:
     )
 
 
-@requires_dbr_version(17)
+@requires_dbr_version("17.1")
 @register_rule("row")
 def is_non_empty_geometry(column: str | Column) -> Column:
     """Checks whether the values in the input column are empty geometries.
@@ -413,7 +414,7 @@ def is_non_empty_geometry(column: str | Column) -> Column:
     )
 
 
-@requires_dbr_version(17)
+@requires_dbr_version("17.1")
 @register_rule("row")
 def is_not_null_island(column: str | Column) -> Column:
     """Checks whether the values in the input column are NULL island geometries (e.g. POINT(0 0), POINTZ(0 0 0), or
@@ -450,7 +451,7 @@ def is_not_null_island(column: str | Column) -> Column:
     )
 
 
-@requires_dbr_version(17)
+@requires_dbr_version("17.1")
 @register_rule("row")
 def has_dimension(column: str | Column, dimension: int) -> Column:
     """Checks whether the geometries/geographies in the input column have a given dimension.
@@ -480,7 +481,7 @@ def has_dimension(column: str | Column, dimension: int) -> Column:
     )
 
 
-@requires_dbr_version(17)
+@requires_dbr_version("17.1")
 @register_rule("row")
 def has_x_coordinate_between(column: str | Column, min_value: float, max_value: float) -> Column:
     """Checks whether the x coordinates of the geometries in the input column are between a given range.
@@ -513,7 +514,7 @@ def has_x_coordinate_between(column: str | Column, min_value: float, max_value: 
     )
 
 
-@requires_dbr_version(17)
+@requires_dbr_version("17.1")
 @register_rule("row")
 def has_y_coordinate_between(column: str | Column, min_value: float, max_value: float) -> Column:
     """Checks whether the y coordinates of the geometries in the input column are between a given range.
@@ -546,7 +547,7 @@ def has_y_coordinate_between(column: str | Column, min_value: float, max_value: 
     )
 
 
-@requires_dbr_version(17)
+@requires_dbr_version("17.1")
 @register_rule("row")
 def is_area_equal_to(
     column: str | Column, value: int | float | str | Column, srid: int | None = 3857, geodesic: bool = False
@@ -584,7 +585,7 @@ def is_area_equal_to(
     )
 
 
-@requires_dbr_version(17)
+@requires_dbr_version("17.1")
 @register_rule("row")
 def is_area_not_equal_to(
     column: str | Column, value: int | float | str | Column, srid: int | None = 3857, geodesic: bool = False
@@ -622,7 +623,7 @@ def is_area_not_equal_to(
     )
 
 
-@requires_dbr_version(17)
+@requires_dbr_version("17.1")
 @register_rule("row")
 def is_area_not_greater_than(
     column: str | Column, value: int | float | str | Column, srid: int | None = 3857, geodesic: bool = False
@@ -660,7 +661,7 @@ def is_area_not_greater_than(
     )
 
 
-@requires_dbr_version(17)
+@requires_dbr_version("17.1")
 @register_rule("row")
 def is_area_not_less_than(
     column: str | Column, value: int | float | str | Column, srid: int | None = 3857, geodesic: bool = False
@@ -698,7 +699,7 @@ def is_area_not_less_than(
     )
 
 
-@requires_dbr_version(17)
+@requires_dbr_version("17.1")
 @register_rule("row")
 def is_num_points_equal_to(column: str | Column, value: int | float | str | Column) -> Column:
     """
@@ -727,7 +728,7 @@ def is_num_points_equal_to(column: str | Column, value: int | float | str | Colu
     )
 
 
-@requires_dbr_version(17)
+@requires_dbr_version("17.1")
 @register_rule("row")
 def is_num_points_not_equal_to(column: str | Column, value: int | float | str | Column) -> Column:
     """
@@ -756,7 +757,7 @@ def is_num_points_not_equal_to(column: str | Column, value: int | float | str | 
     )
 
 
-@requires_dbr_version(17)
+@requires_dbr_version("17.1")
 @register_rule("row")
 def is_num_points_not_greater_than(column: str | Column, value: int | float | str | Column) -> Column:
     """
@@ -785,7 +786,7 @@ def is_num_points_not_greater_than(column: str | Column, value: int | float | st
     )
 
 
-@requires_dbr_version(17)
+@requires_dbr_version("17.1")
 @register_rule("row")
 def is_num_points_not_less_than(column: str | Column, value: int | float | str | Column) -> Column:
     """
@@ -886,7 +887,7 @@ def _compare_spatial_sql_function_result(
     )
 
 
-@requires_dbr_version(17)
+@requires_dbr_version("17.1")
 @register_rule("dataset")
 def are_polygons_mutually_disjoint(
     column: str | Column,
@@ -1087,6 +1088,7 @@ def _has_topological_relationship_approximate(
     )
 
 
+@requires_dbr_version("17.1")
 @register_rule("row")
 def is_geo_contains(
     column: str | Column,
@@ -1129,6 +1131,7 @@ def is_geo_contains(
     )
 
 
+@requires_dbr_version("17.1")
 @register_rule("row")
 def is_geo_covers(
     column: str | Column,
@@ -1178,7 +1181,7 @@ def is_geo_covers(
         InvalidParameterError: If *precise* is False and *resolution* is not provided or is outside 0–15.
 
     Note:
-        This function requires Databricks serverless compute or runtime 17.1 or above.
+        This function requires Databricks serverless compute or runtime 17.1 or above if `precise` is True.
     """
     if precise:
         return _has_topological_relationship_precise(
@@ -1191,6 +1194,7 @@ def is_geo_covers(
     return _has_topological_relationship_approximate(column, reference_geometry, resolution, "COVERS")
 
 
+@requires_dbr_version("17.1")
 @register_rule("row")
 def is_geo_intersects(
     column: str | Column,
@@ -1238,7 +1242,7 @@ def is_geo_intersects(
         InvalidParameterError: If *precise* is False and *resolution* is not provided or is outside 0–15.
 
     Note:
-        This function requires Databricks serverless compute or runtime 17.1 or above.
+        This function requires Databricks serverless compute or runtime 17.1 or above if `precise` is True.
     """
     if precise:
         return _has_topological_relationship_precise(
@@ -1251,7 +1255,7 @@ def is_geo_intersects(
     return _has_topological_relationship_approximate(column, reference_geometry, resolution, "INTERSECTS")
 
 
-@requires_dbr_version(17)
+@requires_dbr_version("17.1")
 @register_rule("row")
 def is_geo_touches(
     column: str | Column,
@@ -1292,7 +1296,7 @@ def is_geo_touches(
     )
 
 
-@requires_dbr_version(17)
+@requires_dbr_version("17.1")
 @register_rule("row")
 def is_geo_within(
     column: str | Column,

--- a/src/databricks/labs/dqx/rule.py
+++ b/src/databricks/labs/dqx/rule.py
@@ -29,7 +29,7 @@ __all__ = [
     "SingleColumnMixin",
     "normalize_bound_args",
     "register_for_original_columns_preselection",
-    "CHECK_FUNC_DBR_VERSION_REQUIREMENT_ATTRIBUTE",
+    "CHECK_FUNC_MIN_DBR_VERSION_ATTRIBUTE",
     "register_rule",
     "requires_dbr_version",
 ]
@@ -37,7 +37,7 @@ __all__ = [
 CHECK_FUNC_REGISTRY: dict[str, str] = {}
 CHECK_FUNC_REGISTRY_ORIGINAL_COLUMNS_PRESELECTION: set[str] = set()
 
-CHECK_FUNC_DBR_VERSION_REQUIREMENT_ATTRIBUTE = "dqx_requires_dbr_major_version"
+CHECK_FUNC_MIN_DBR_VERSION_ATTRIBUTE = "dqx_requires_dbr_version"
 
 
 def register_rule(rule_type: str) -> Callable:
@@ -56,33 +56,48 @@ def register_for_original_columns_preselection() -> Callable:
     return wrapper
 
 
-def requires_dbr_version(major_version: int) -> Callable:
-    """Annotates a check function with a minimum Databricks Runtime major version requirement.
+def requires_dbr_version(version: str) -> Callable:
+    """Annotates a check function with a minimum Databricks Runtime version requirement.
 
-    Sets the *dqx_requires_dbr_major_version* attribute on the decorated function. The engine
-    reads this attribute before execution and raises an error if the current Databricks Runtime
-    major version is lower than the required one, failing the entire run.
+    Parses *version* into a *(major, minor)* tuple and sets it as the
+    *dqx_requires_dbr_version* attribute on the decorated function. The engine reads
+    this attribute before execution and raises an error if the current Databricks
+    Runtime version is lower than the required one, failing the entire run.
 
     Example usage:
 
     ```python
-    @requires_dbr_version(15)
+    @requires_dbr_version("15.1")
     @register_rule("row")
     def my_check(column: str) -> Column:
         ...
     ```
 
     Args:
-        major_version: The minimum required Databricks Runtime major version (e.g., 15).
+        version: The minimum required Databricks Runtime version in *"major.minor"* format (e.g., *"15.1"*).
 
     Returns:
         A decorator that annotates the function with the DBR version requirement.
+
+    Raises:
+        ValueError: If *version* is not a valid *"major.minor"* string with non-negative integer components.
     """
-    if major_version < 1:
-        raise InvalidParameterError(f"Major version must be greater than or equal to 1. Given {major_version}.")
+    parts = version.split(".")
+    if len(parts) != 2:
+        raise ValueError(f"DBR version must be in 'major.minor' format, got: '{version}'")
+
+    try:
+        major, minor = int(parts[0]), int(parts[1])
+    except ValueError as e:
+        raise ValueError(f"DBR version components must be integers, got: '{version}'") from e
+
+    if major < 0 or minor < 0:
+        raise ValueError(f"DBR version components must be non-negative, got: '{version}'")
+
+    parsed: tuple[int, int] = (major, minor)
 
     def wrapper(func: Callable) -> Callable:
-        setattr(func, CHECK_FUNC_DBR_VERSION_REQUIREMENT_ATTRIBUTE, major_version)
+        setattr(func, CHECK_FUNC_MIN_DBR_VERSION_ATTRIBUTE, parsed)
         return func
 
     return wrapper

--- a/src/databricks/labs/dqx/rule.py
+++ b/src/databricks/labs/dqx/rule.py
@@ -29,11 +29,15 @@ __all__ = [
     "SingleColumnMixin",
     "normalize_bound_args",
     "register_for_original_columns_preselection",
+    "CHECK_FUNC_DBR_VERSION_REQUIREMENT_ATTRIBUTE",
     "register_rule",
+    "requires_dbr_version",
 ]
 
 CHECK_FUNC_REGISTRY: dict[str, str] = {}
 CHECK_FUNC_REGISTRY_ORIGINAL_COLUMNS_PRESELECTION: set[str] = set()
+
+CHECK_FUNC_DBR_VERSION_REQUIREMENT_ATTRIBUTE = "dqx_requires_dbr_major_version"
 
 
 def register_rule(rule_type: str) -> Callable:
@@ -47,6 +51,38 @@ def register_rule(rule_type: str) -> Callable:
 def register_for_original_columns_preselection() -> Callable:
     def wrapper(func: Callable) -> Callable:
         CHECK_FUNC_REGISTRY_ORIGINAL_COLUMNS_PRESELECTION.add(func.__name__)
+        return func
+
+    return wrapper
+
+
+def requires_dbr_version(major_version: int) -> Callable:
+    """Annotates a check function with a minimum Databricks Runtime major version requirement.
+
+    Sets the *dqx_requires_dbr_major_version* attribute on the decorated function. The engine
+    reads this attribute before execution and raises an error if the current Databricks Runtime
+    major version is lower than the required one, failing the entire run.
+
+    Example usage:
+
+    ```python
+    @requires_dbr_version(15)
+    @register_rule("row")
+    def my_check(column: str) -> Column:
+        ...
+    ```
+
+    Args:
+        major_version: The minimum required Databricks Runtime major version (e.g., 15).
+
+    Returns:
+        A decorator that annotates the function with the DBR version requirement.
+    """
+    if major_version < 1:
+        raise InvalidParameterError(f"Major version must be greater than or equal to 1. Given {major_version}.")
+
+    def wrapper(func: Callable) -> Callable:
+        setattr(func, CHECK_FUNC_DBR_VERSION_REQUIREMENT_ATTRIBUTE, major_version)
         return func
 
     return wrapper

--- a/tests/integration/test_engine.py
+++ b/tests/integration/test_engine.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 from pyspark.sql import Column
 import pyspark.sql.functions as F
@@ -11,13 +13,28 @@ from databricks.labs.dqx.rule import DQRowRule, register_rule, requires_dbr_vers
 @requires_dbr_version("1.0")
 @register_rule("row")
 def _check_requires_dbr_v1(column: str) -> Column:
-    return make_condition(F.col(column).isNull(), f"\'{column}\' is null", f"{column}_is_null")
+    return make_condition(F.col(column).isNull(), f"'{column}' is null", f"{column}_is_null")
 
 
-@requires_dbr_version("999.0")
-@register_rule("row")
-def _check_requires_dbr_max(column: str) -> Column:
-    return make_condition(F.col(column).isNull(), f"\'{column}\' is null", f"{column}_is_null")
+def _row_check_requiring(version: str):
+    """Build a row check decorated with a dynamic minimum DBR requirement."""
+
+    @requires_dbr_version(version)
+    @register_rule("row")
+    def _check(column: str) -> Column:
+        return make_condition(F.col(column).isNull(), f"'{column}' is null", f"{column}_is_null")
+
+    return _check
+
+
+def _current_dbr_version(spark) -> tuple[int, int] | None:
+    """Resolve the current runtime as a (major, minor) tuple, or None when undetermined (e.g. serverless)."""
+    rows = spark.sql("select current_version().dbr_version as dbr_version").collect()
+    version_str = rows[0]["dbr_version"] if rows else None
+    if not version_str or not version_str.strip():
+        return None
+    match = re.match(r"\s*(\d+)\.(\d+)", version_str)
+    return (int(match.group(1)), int(match.group(2))) if match else None
 
 
 def test_apply_checks_passes_when_dbr_version_requirement_satisfied(ws, spark):
@@ -26,8 +43,27 @@ def test_apply_checks_passes_when_dbr_version_requirement_satisfied(ws, spark):
     engine.apply_checks(df, [DQRowRule(check_func=_check_requires_dbr_v1, column="a")])
 
 
-def test_apply_checks_raises_when_dbr_version_requirement_not_satisfied(ws, spark):
+def test_apply_checks_passes_on_serverless(ws, spark, skip_if_classic_compute):
+    # Serverless reports a suffixed version such as "18.2.x-photon-scala2.13"; the 17.1 requirement carried by
+    # the geo checks must parse the leading major.minor and pass, not be blocked by the suffix.
     engine = DQEngine(ws)
     df = spark.createDataFrame([("value",)], "a: string")
-    with pytest.raises(InvalidCheckError, match=r"Check functions \[.*\] require Databricks Runtime"):
-        engine.apply_checks(df, [DQRowRule(check_func=_check_requires_dbr_max, column="a")])
+    engine.apply_checks(df, [DQRowRule(check_func=_row_check_requiring("17.1"), column="a")])
+
+
+def test_apply_checks_dbr_version_boundary_is_minor_version_aware(ws, spark):
+    current = _current_dbr_version(spark)
+    if current is None:
+        pytest.skip("Requires a resolvable DBR version; the current runtime returned none")
+
+    major, minor = current
+    engine = DQEngine(ws)
+    df = spark.createDataFrame([("value",)], "a: string")
+
+    # Exactly the current version must pass - guards against a '<' -> '<=' regression.
+    engine.apply_checks(df, [DQRowRule(check_func=_row_check_requiring(f"{major}.{minor}"), column="a")])
+
+    # One minor above the current version must fail - guards against a major-only comparison that would
+    # wrongly let an equal major with a lower minor through.
+    with pytest.raises(InvalidCheckError, match="require Databricks Runtime"):
+        engine.apply_checks(df, [DQRowRule(check_func=_row_check_requiring(f"{major}.{minor + 1}"), column="a")])

--- a/tests/integration/test_engine.py
+++ b/tests/integration/test_engine.py
@@ -1,5 +1,3 @@
-import sys
-
 import pytest
 from pyspark.sql import Column
 import pyspark.sql.functions as F
@@ -10,16 +8,16 @@ from databricks.labs.dqx.errors import InvalidCheckError
 from databricks.labs.dqx.rule import DQRowRule, register_rule, requires_dbr_version
 
 
-@requires_dbr_version(1)
+@requires_dbr_version("1.0")
 @register_rule("row")
 def _check_requires_dbr_v1(column: str) -> Column:
-    return make_condition(F.col(column).isNull(), f"'{column}' is null", f"{column}_is_null")
+    return make_condition(F.col(column).isNull(), f"\'{column}\' is null", f"{column}_is_null")
 
 
-@requires_dbr_version(sys.maxsize)
+@requires_dbr_version("999.0")
 @register_rule("row")
 def _check_requires_dbr_max(column: str) -> Column:
-    return make_condition(F.col(column).isNull(), f"'{column}' is null", f"{column}_is_null")
+    return make_condition(F.col(column).isNull(), f"\'{column}\' is null", f"{column}_is_null")
 
 
 def test_apply_checks_passes_when_dbr_version_requirement_satisfied(ws, spark):

--- a/tests/integration/test_engine.py
+++ b/tests/integration/test_engine.py
@@ -1,0 +1,35 @@
+import sys
+
+import pytest
+from pyspark.sql import Column
+import pyspark.sql.functions as F
+
+from databricks.labs.dqx.check_funcs import make_condition
+from databricks.labs.dqx.engine import DQEngine
+from databricks.labs.dqx.errors import InvalidCheckError
+from databricks.labs.dqx.rule import DQRowRule, register_rule, requires_dbr_version
+
+
+@requires_dbr_version(1)
+@register_rule("row")
+def _check_requires_dbr_v1(column: str) -> Column:
+    return make_condition(F.col(column).isNull(), f"'{column}' is null", f"{column}_is_null")
+
+
+@requires_dbr_version(sys.maxsize)
+@register_rule("row")
+def _check_requires_dbr_max(column: str) -> Column:
+    return make_condition(F.col(column).isNull(), f"'{column}' is null", f"{column}_is_null")
+
+
+def test_apply_checks_passes_when_dbr_version_requirement_satisfied(ws, spark):
+    engine = DQEngine(ws)
+    df = spark.createDataFrame([("value",)], "a: string")
+    engine.apply_checks(df, [DQRowRule(check_func=_check_requires_dbr_v1, column="a")])
+
+
+def test_apply_checks_raises_when_dbr_version_requirement_not_satisfied(ws, spark):
+    engine = DQEngine(ws)
+    df = spark.createDataFrame([("value",)], "a: string")
+    with pytest.raises(InvalidCheckError, match=r"Check functions \[.*\] require Databricks Runtime"):
+        engine.apply_checks(df, [DQRowRule(check_func=_check_requires_dbr_max, column="a")])

--- a/tests/unit/test_build_rules.py
+++ b/tests/unit/test_build_rules.py
@@ -41,6 +41,8 @@ from databricks.labs.dqx.rule import (
     CHECK_FUNC_REGISTRY,
     register_rule,
     DQDatasetRule,
+    requires_dbr_version,
+    CHECK_FUNC_DBR_VERSION_REQUIREMENT_ATTRIBUTE,
 )
 from databricks.labs.dqx.checks_serializer import (
     ChecksSerializer,
@@ -1988,3 +1990,39 @@ def test_dq_dataset_rule_rule_fingerprint():
     fingerprint = rule.rule_fingerprint
     assert len(fingerprint) == 64
     assert all(char in "0123456789abcdef" for char in fingerprint)
+
+
+def test_requires_dbr_version_sets_attribute():
+    @requires_dbr_version(15)
+    def my_check():
+        pass
+
+    assert getattr(my_check, CHECK_FUNC_DBR_VERSION_REQUIREMENT_ATTRIBUTE) == 15
+
+
+def test_requires_dbr_version_stacked_with_register_rule():
+    @requires_dbr_version(14)
+    @register_rule("row")
+    def my_versioned_check():
+        pass
+
+    assert getattr(my_versioned_check, CHECK_FUNC_DBR_VERSION_REQUIREMENT_ATTRIBUTE) == 14
+    assert CHECK_FUNC_REGISTRY.get("my_versioned_check") == "row"
+
+
+def test_requires_register_rule_stacked_with_dbr_version_stacked():
+    @register_rule("row")
+    @requires_dbr_version(14)
+    def my_versioned_check():
+        pass
+
+    assert getattr(my_versioned_check, CHECK_FUNC_DBR_VERSION_REQUIREMENT_ATTRIBUTE) == 14
+    assert CHECK_FUNC_REGISTRY.get("my_versioned_check") == "row"
+
+
+def test_requires_dbr_version_returns_same_function():
+    def my_check():
+        pass
+
+    decorated = requires_dbr_version(12)(my_check)
+    assert decorated is my_check

--- a/tests/unit/test_build_rules.py
+++ b/tests/unit/test_build_rules.py
@@ -42,7 +42,7 @@ from databricks.labs.dqx.rule import (
     register_rule,
     DQDatasetRule,
     requires_dbr_version,
-    CHECK_FUNC_DBR_VERSION_REQUIREMENT_ATTRIBUTE,
+    CHECK_FUNC_MIN_DBR_VERSION_ATTRIBUTE,
 )
 from databricks.labs.dqx.checks_serializer import (
     ChecksSerializer,
@@ -1993,30 +1993,30 @@ def test_dq_dataset_rule_rule_fingerprint():
 
 
 def test_requires_dbr_version_sets_attribute():
-    @requires_dbr_version(15)
+    @requires_dbr_version("15.0")
     def my_check():
         pass
 
-    assert getattr(my_check, CHECK_FUNC_DBR_VERSION_REQUIREMENT_ATTRIBUTE) == 15
+    assert getattr(my_check, CHECK_FUNC_MIN_DBR_VERSION_ATTRIBUTE) == (15, 0)
 
 
 def test_requires_dbr_version_stacked_with_register_rule():
-    @requires_dbr_version(14)
+    @requires_dbr_version("14.0")
     @register_rule("row")
     def my_versioned_check():
         pass
 
-    assert getattr(my_versioned_check, CHECK_FUNC_DBR_VERSION_REQUIREMENT_ATTRIBUTE) == 14
+    assert getattr(my_versioned_check, CHECK_FUNC_MIN_DBR_VERSION_ATTRIBUTE) == (14, 0)
     assert CHECK_FUNC_REGISTRY.get("my_versioned_check") == "row"
 
 
 def test_requires_register_rule_stacked_with_dbr_version_stacked():
     @register_rule("row")
-    @requires_dbr_version(14)
+    @requires_dbr_version("14.1")
     def my_versioned_check():
         pass
 
-    assert getattr(my_versioned_check, CHECK_FUNC_DBR_VERSION_REQUIREMENT_ATTRIBUTE) == 14
+    assert getattr(my_versioned_check, CHECK_FUNC_MIN_DBR_VERSION_ATTRIBUTE) == (14, 1)
     assert CHECK_FUNC_REGISTRY.get("my_versioned_check") == "row"
 
 
@@ -2024,5 +2024,11 @@ def test_requires_dbr_version_returns_same_function():
     def my_check():
         pass
 
-    decorated = requires_dbr_version(12)(my_check)
+    decorated = requires_dbr_version("12.0")(my_check)
     assert decorated is my_check
+
+
+@pytest.mark.parametrize("bad_version", ["15", "15.4.1", "abc.def", "-1.0", "15.-1", ""])
+def test_requires_dbr_version_raises_on_invalid_version(bad_version):
+    with pytest.raises(ValueError):
+        requires_dbr_version(bad_version)

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -1,8 +1,10 @@
+import re
 from datetime import datetime, timezone
 from unittest.mock import create_autospec, Mock
 
 import pytest
 import pyspark.sql.functions as F
+from pyspark.errors import AnalysisException
 from pyspark.sql import Column, SparkSession
 
 from databricks.sdk import WorkspaceClient
@@ -375,6 +377,18 @@ def _check_requires_dbr_15(column: str) -> Column:
     return make_condition(F.col(column).isNull(), f"'{column}' is null", f"{column}_is_null")
 
 
+@requires_dbr_version("17.1")
+@register_rule("row")
+def _check_requires_dbr_17_1(column: str) -> Column:
+    return make_condition(F.col(column).isNull(), f"'{column}' is null", f"{column}_is_null")
+
+
+@requires_dbr_version("999.0")
+@register_rule("row")
+def _check_requires_dbr_max(column: str) -> Column:
+    return make_condition(F.col(column).isNull(), f"'{column}' is null", f"{column}_is_null")
+
+
 def _engine_with_sql_side_effect(side_effect):
     ws = create_autospec(WorkspaceClient)
     spark = create_autospec(SparkSession)
@@ -392,24 +406,10 @@ def _engine_returning_dbr_version(version_str):
 
 
 def test_apply_checks_raises_invalid_check_error_when_spark_sql_fails():
-    from pyspark.sql.utils import AnalysisException
     engine = _engine_with_sql_side_effect(AnalysisException("current_version() not found"))
     df = Mock()
     df.columns = ["a"]
     with pytest.raises(InvalidCheckError, match="can only run on Databricks Runtime"):
-        engine.apply_checks(df, [DQRowRule(check_func=_check_requires_dbr_15, column="a")])
-
-
-def test_apply_checks_raises_invalid_check_error_when_dbr_version_is_null():
-    ws = create_autospec(WorkspaceClient)
-    spark = create_autospec(SparkSession)
-    row = Mock()
-    row.__getitem__ = Mock(return_value=None)
-    spark.sql.return_value.collect.return_value = [row]
-    engine = DQEngineCore(workspace_client=ws, spark=spark)
-    df = Mock()
-    df.columns = ["a"]
-    with pytest.raises(InvalidCheckError, match="returned null"):
         engine.apply_checks(df, [DQRowRule(check_func=_check_requires_dbr_15, column="a")])
 
 
@@ -419,3 +419,36 @@ def test_apply_checks_raises_invalid_check_error_when_dbr_version_unparseable():
     df.columns = ["a"]
     with pytest.raises(InvalidCheckError, match="Cannot parse Databricks Runtime version"):
         engine.apply_checks(df, [DQRowRule(check_func=_check_requires_dbr_15, column="a")])
+
+
+@pytest.mark.parametrize("dbr_version", ["17.0", "16.4", "9.1"])
+def test_apply_checks_raises_when_minor_version_below_required(dbr_version):
+    # Required 17.1; a lower (major, minor) - including 17.0, the same major - must fail. Guards against a
+    # regression to major-only comparison, which would wrongly let 17.0 through.
+    engine = _engine_returning_dbr_version(dbr_version)
+    df = Mock()
+    df.columns = ["a"]
+    with pytest.raises(InvalidCheckError, match=r"require Databricks Runtime >= 17\.1"):
+        engine.apply_checks(df, [DQRowRule(check_func=_check_requires_dbr_17_1, column="a")])
+
+
+@pytest.mark.parametrize(
+    "dbr_version, required_check",
+    [
+        # A suffixed runtime string such as "15.4 LTS" must parse to (15, 4) rather than hard-fail.
+        ("15.4 LTS", _check_requires_dbr_17_1),
+        # Serverless reports e.g. "18.2.x-photon-scala2.13"; it must parse to (18, 2), not hard-fail.
+        ("18.2.x-photon-scala2.13", _check_requires_dbr_max),
+    ],
+)
+def test_apply_checks_parses_dbr_version_with_suffix(dbr_version, required_check):
+    # Asserting the version is compared (and echoed back) against a higher requirement proves the leading
+    # major.minor was parsed and the suffix ignored, rather than the parse hard-failing.
+    engine = _engine_returning_dbr_version(dbr_version)
+    df = Mock()
+    df.columns = ["a"]
+    with pytest.raises(
+        InvalidCheckError,
+        match=rf"require Databricks Runtime >= .*but the current version is {re.escape(dbr_version)}",
+    ):
+        engine.apply_checks(df, [DQRowRule(check_func=required_check, column="a")])

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -3,7 +3,7 @@ from unittest.mock import create_autospec, Mock
 
 import pytest
 import pyspark.sql.functions as F
-from pyspark.sql import SparkSession
+from pyspark.sql import Column, SparkSession
 
 from databricks.sdk import WorkspaceClient
 from databricks.sdk.errors import DatabricksError
@@ -19,9 +19,10 @@ from databricks.labs.dqx.checks_storage import (
 from databricks.labs.dqx.config import InputConfig, OutputConfig
 from databricks.labs.dqx.base import DQEngineBase
 from databricks.labs.dqx.engine import DQEngine, DQEngineCore
-from databricks.labs.dqx.engine import InvalidParameterError
+from databricks.labs.dqx.engine import InvalidCheckError, InvalidParameterError
 from databricks.labs.dqx.metrics_observer import DQMetricsObserver
-from databricks.labs.dqx.rule import DQDatasetRule
+from databricks.labs.dqx.check_funcs import make_condition
+from databricks.labs.dqx.rule import DQDatasetRule, DQRowRule, register_rule, requires_dbr_version
 
 
 def test_engine_creation():
@@ -363,3 +364,58 @@ def test_apply_checks_by_metadata_and_save_in_table_raises_when_no_destination_c
             input_config=InputConfig(location="catalog.schema.input"),
             checks=[],
         )
+
+
+# --- DBR version validation error path tests ---
+
+
+@requires_dbr_version("15.0")
+@register_rule("row")
+def _check_requires_dbr_15(column: str) -> Column:
+    return make_condition(F.col(column).isNull(), f"'{column}' is null", f"{column}_is_null")
+
+
+def _engine_with_sql_side_effect(side_effect):
+    ws = create_autospec(WorkspaceClient)
+    spark = create_autospec(SparkSession)
+    spark.sql.side_effect = side_effect
+    return DQEngineCore(workspace_client=ws, spark=spark)
+
+
+def _engine_returning_dbr_version(version_str):
+    ws = create_autospec(WorkspaceClient)
+    spark = create_autospec(SparkSession)
+    row = Mock()
+    row.__getitem__ = Mock(return_value=version_str)
+    spark.sql.return_value.collect.return_value = [row]
+    return DQEngineCore(workspace_client=ws, spark=spark)
+
+
+def test_apply_checks_raises_invalid_check_error_when_spark_sql_fails():
+    from pyspark.sql.utils import AnalysisException
+    engine = _engine_with_sql_side_effect(AnalysisException("current_version() not found"))
+    df = Mock()
+    df.columns = ["a"]
+    with pytest.raises(InvalidCheckError, match="can only run on Databricks Runtime"):
+        engine.apply_checks(df, [DQRowRule(check_func=_check_requires_dbr_15, column="a")])
+
+
+def test_apply_checks_raises_invalid_check_error_when_dbr_version_is_null():
+    ws = create_autospec(WorkspaceClient)
+    spark = create_autospec(SparkSession)
+    row = Mock()
+    row.__getitem__ = Mock(return_value=None)
+    spark.sql.return_value.collect.return_value = [row]
+    engine = DQEngineCore(workspace_client=ws, spark=spark)
+    df = Mock()
+    df.columns = ["a"]
+    with pytest.raises(InvalidCheckError, match="returned null"):
+        engine.apply_checks(df, [DQRowRule(check_func=_check_requires_dbr_15, column="a")])
+
+
+def test_apply_checks_raises_invalid_check_error_when_dbr_version_unparseable():
+    engine = _engine_returning_dbr_version("custom-build")
+    df = Mock()
+    df.columns = ["a"]
+    with pytest.raises(InvalidCheckError, match="Cannot parse Databricks Runtime version"):
+        engine.apply_checks(df, [DQRowRule(check_func=_check_requires_dbr_15, column="a")])


### PR DESCRIPTION
## Changes
Verifies minimal Databricks environment version before checks execution. The implementation differs from the suggestion in the original ticket to preserve backward compatibility. New annotation stores additional property in the function. Additionally covered geo-checks that has DBR requirements in the description.

### Linked issues
Resolves #1225 

### Tests

- [ ] manually tested
- [x] added unit tests
- [x] added integration tests
- [ ] added end-to-end tests
- [ ] added performance tests

### Documentation and Demos
<!-- Any user facing changes require documentation and demos update -->

- [ ] added/updated demos
- [ ] added/updated docs
- [ ] added/updated agent skills
