### PR TITLE
Fix app installation for Windows

### DIFF
--- a/app/scripts/build_app.py
+++ b/app/scripts/build_app.py
@@ -36,6 +36,7 @@ Designed to be cwd-independent — paths resolve relative to this file.
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 import tomllib
@@ -67,6 +68,12 @@ def _run(cmd: list[str]) -> None:
     """
     print(f"  $ {' '.join(cmd)}", flush=True)
     subprocess.run(cmd, cwd=APP_DIR, check=True)  # noqa: S603
+
+
+def _node_bin(name: str) -> str:
+    """Return the path to a ``node_modules/.bin`` executable for this platform."""
+    suffix = ".cmd" if os.name == "nt" else ""
+    return str(NODE_BIN / f"{name}{suffix}")
 
 
 def _load_pyproject() -> dict:
@@ -160,7 +167,7 @@ def _run_orval() -> None:
     locally-installed binary directly so the pinned ``orval`` is used
     regardless of which package manager is on PATH.
     """
-    _run([str(NODE_BIN / "orval")])
+    _run([_node_bin("orval")])
 
 
 def _run_vite_build() -> None:
@@ -169,7 +176,7 @@ def _run_vite_build() -> None:
     Vite reads ``vite.config.ts``, which sets ``build.outDir`` to the
     package's ``__dist__`` folder so it ships inside the package source.
     """
-    _run([str(NODE_BIN / "vite"), "build"])
+    _run([_node_bin("vite"), "build"])
 
 
 def _assemble_deploy_tree() -> None:

--- a/app/tests/test_build_app.py
+++ b/app/tests/test_build_app.py
@@ -1,0 +1,45 @@
+"""Tests for ``app/scripts/build_app.py``."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+BUILD_APP_PATH = Path(__file__).resolve().parent.parent / "scripts" / "build_app.py"
+
+
+@pytest.mark.parametrize(
+    ("runner", "tool", "extra_args"),
+    [
+        ("_run_orval", "orval", []),
+        ("_run_vite_build", "vite", ["build"]),
+    ],
+)
+@pytest.mark.parametrize(
+    ("os_name", "expected_suffix"),
+    [("posix", ""), ("nt", ".cmd")],
+)
+def test_node_runners_pick_platform_shim(monkeypatch, runner, tool, extra_args, os_name, expected_suffix):
+    captured = []
+    build_app = _load_build_app()
+
+    def _fake_run(cmd, **_kwargs):
+        captured.append(cmd)
+
+    monkeypatch.setattr(build_app.os, "name", os_name)
+    monkeypatch.setattr(build_app.subprocess, "run", _fake_run)
+
+    getattr(build_app, runner)()
+
+    cmd = captured[0]
+    assert cmd[0] == str(build_app.NODE_BIN / f"{tool}{expected_suffix}")
+    assert cmd[1:] == extra_args
+
+
+def _load_build_app():
+    spec = importlib.util.spec_from_file_location("build_app", BUILD_APP_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module

--- a/src/databricks/labs/dqx/installer/install.py
+++ b/src/databricks/labs/dqx/installer/install.py
@@ -346,13 +346,19 @@ class InstallationService:
             return
 
         logger.info(f"Deleting DQX v{self._product_info.version()} from {self._ws.config.host}")
+
+        # Remove workflow jobs first, independently of the install folder. Jobs and the install folder
+        # are separate resources: if the folder is already gone (partial/failed install, or a prior
+        # cleanup step), gating job removal behind files() would orphan the jobs and leak them toward
+        # the workspace job limit.
+        self._workflow_installer.remove_jobs()
+
         try:
             self._installation.files()  # this also deletes the dashboard
         except NotFound:
             logger.error(f"Check if {self._installation.install_folder()} is present")
             return
 
-        self._workflow_installer.remove_jobs()
         default_run_config = self._config.get_run_config()
         self._warehouse_configurator.remove(default_run_config.warehouse_id)
         self._installation.remove()

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -1,4 +1,9 @@
 import logging
+import os
+import re
+from collections.abc import Callable
+from datetime import datetime, timedelta, timezone
+from functools import partial
 from unittest import skip
 from unittest.mock import patch, create_autospec
 import pytest
@@ -609,3 +614,62 @@ def test_install_config_rejects_no_output_and_no_quarantine(ws):
         match="At least one of an output table or a quarantine table",
     ):
         installer.configure()
+
+
+# DQX installs its workflows as jobs named "[<INSTALL_FOLDER>] <workflow>" (see mixins._get_name);
+# the workflow suffix is one of the deployed steps below.
+_DQX_JOB_NAME_PATTERN = re.compile(r"^\[.+\] (profiler|quality-checker|e2e|anomaly-trainer)$")
+
+
+def _safe_delete_job(delete: Callable[[], object], name: str) -> None:
+    """Best-effort delete: a single failure is logged and never blocks the rest of the sweep."""
+    try:
+        delete()
+    except NotFound:
+        pass
+    except Exception as e:  # noqa: BLE001 — best-effort sweep must not block the test run
+        logger.warning(f"Failed to delete orphaned DQX job '{name}': {e}")
+
+
+def _remove_orphaned_jobs(ws) -> None:
+    """Delete orphaned DQX workflow jobs (profiler, quality-checker, e2e, anomaly-trainer) left behind
+    by cancelled CI runs.
+
+    Orphaned jobs accumulate when a github action is cancelled and the ``installation_ctx`` fixture
+    teardown (which calls ``uninstall()`` to remove the deployed jobs) does not run. Jobs count toward
+    the per-workspace job limit, so they are swept explicitly here, mirroring the orphaned-Lakebase
+    sweep.
+
+    Runs only in CI. Jobs younger than the 2h grace period are skipped so a concurrent run's freshly
+    deployed jobs (and the current run's own jobs) are never deleted; a real long-lived install is
+    protected because the sweep only runs in the ephemeral CI test workspace.
+    """
+    run_id = os.getenv("GITHUB_RUN_ID")
+    if not run_id:
+        return  # only applicable when run in CI
+
+    grace_period = datetime.now(timezone.utc) - timedelta(hours=2)  # aligned with tests timeout
+
+    matched = attempted = 0
+    for job in ws.jobs.list():
+        name = (job.settings.name if job.settings else None) or ""
+        if not _DQX_JOB_NAME_PATTERN.match(name):
+            continue
+        matched += 1
+        created = datetime.fromtimestamp(job.created_time / 1000, tz=timezone.utc) if job.created_time else None
+        if created is not None and created >= grace_period:
+            continue  # too young — may belong to a concurrent or the current run
+        _safe_delete_job(partial(ws.jobs.delete, job_id=job.job_id), name)
+        attempted += 1
+    logger.info(f"DQX job sweep: matched_naming={matched} delete_attempts={attempted}")
+
+
+def test_remove_orphaned_jobs(ws):
+    """Maintenance sweep: remove orphaned DQX workflow jobs left by cancelled CI runs.
+
+    Mirrors the orphaned-Lakebase-resource sweep. Deployed workflow jobs (profiler, quality-checker,
+    e2e, anomaly-trainer) count toward the per-workspace job limit and are only cleaned by the
+    installation fixture teardown, so a cancelled run leaks them. Runs only in CI; jobs younger than
+    the 2h grace period are skipped.
+    """
+    _remove_orphaned_jobs(ws)


### PR DESCRIPTION
## Changes
<!-- Summary of your changes that are easy to understand. Add screenshots when necessary -->
This PR fixes the DQX Studio installation script (`build_app.py`) for Windows machines. We add the `.cmd` suffix to node binaries after detecting the OS:

```
def _node_bin(name: str) -> str:
    """Return the path to a ``node_modules/.bin`` executable for this platform."""
    suffix = ".cmd" if os.name == "nt" else ""
    return str(NODE_BIN / f"{name}{suffix}")
```

Minor fix: Add job sweep to remove orphaned jobs in CI

### Linked issues
<!-- DOC: Link issue with a keyword: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved. See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Resolves #1326 

### Tests
<!-- How is this tested? Please see the checklist below and also describe any other relevant tests -->

- [x] manually tested
- [x] added unit tests
- [ ] added integration tests
- [ ] added end-to-end tests
- [ ] added performance tests

### Documentation and Demos
<!-- Any user facing changes require documentation and demos update -->

- [ ] added/updated demos
- [ ] added/updated docs
- [ ] added/updated agent skills
