### PR TITLE
Make telemetry best-effort: never throw, dedup per process, bounded timeout (#1355)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -892,6 +892,7 @@ redefining-builtins-modules = ["six.moves", "past.builtins", "future.builtins", 
 "tests/unit/test_anomaly_scoring_run.py" = "protected-access"
 "tests/integration_anomaly/test_anomaly_ai_explanation.py" = "protected-access"
 "tests/unit/test_checks_storage.py" = "protected-access"
+"tests/unit/test_telemetry.py" = "protected-access"
 
 # This plugin is used to generate correct links in README showed on PyPi
 [tool.hatch.metadata.hooks.fancy-pypi-readme]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -892,7 +892,6 @@ redefining-builtins-modules = ["six.moves", "past.builtins", "future.builtins", 
 "tests/unit/test_anomaly_scoring_run.py" = "protected-access"
 "tests/integration_anomaly/test_anomaly_ai_explanation.py" = "protected-access"
 "tests/unit/test_checks_storage.py" = "protected-access"
-"tests/unit/test_telemetry.py" = "protected-access"
 
 # This plugin is used to generate correct links in README showed on PyPi
 [tool.hatch.metadata.hooks.fancy-pypi-readme]

--- a/src/databricks/labs/dqx/telemetry.py
+++ b/src/databricks/labs/dqx/telemetry.py
@@ -4,6 +4,7 @@ import functools
 import logging
 import hashlib
 from io import StringIO
+from collections import OrderedDict
 from collections.abc import Callable
 from pyspark.sql import DataFrame, SparkSession
 from databricks.sdk import WorkspaceClient
@@ -21,11 +22,19 @@ _TELEMETRY_TIMEOUT_SECONDS = 5
 # already sent means the ping fires at most once per signal instead of once per check per micro-batch
 # — bounding both the load on the control plane and the number of times a brownout can stall a caller.
 #
-# No lock: set membership/add are atomic under the GIL and add is idempotent, so the cache can never be
-# corrupted. The only thing a lock would add is preventing a rare check-then-add race under concurrent
-# callers (e.g. overlapping foreachBatch micro-batches) from firing one duplicate ping — harmless for a
-# best-effort, timeout-bounded call, so it isn't worth the extra machinery.
-_sent_telemetry: set[tuple[str, str]] = set()
+# Most signals are naturally bounded (a fixed set of check names, streaming/dlt/workflow flags), but
+# input_table / input_path add one hashed entry per *distinct* input, so a very long-lived process that
+# reads an ever-growing set of tables could accumulate unboundedly. Cap the cache and evict oldest-first
+# (FIFO via OrderedDict) so memory is hard-bounded; the realistic ceiling is far below the cap, so
+# eviction only ever kicks in for pathological workloads and merely allows an evicted signal to be
+# re-sent once later — harmless for best-effort telemetry.
+#
+# No lock: dict membership/set/popitem are atomic under the GIL. A concurrent check-then-add race can at
+# most fire one duplicate ping, and since eviction only runs when the cache is over capacity (never near
+# empty) a concurrent eviction can at most drop one extra entry — both harmless for a best-effort call,
+# so a lock isn't worth the machinery.
+_TELEMETRY_CACHE_MAX_SIZE = 10_000
+_sent_telemetry: "OrderedDict[tuple[str, str], None]" = OrderedDict()
 
 
 def reset_telemetry_cache() -> None:
@@ -55,7 +64,10 @@ def log_telemetry(ws: WorkspaceClient, key: str, value: str) -> None:
     # cannot re-stall the caller on every subsequent micro-batch.
     if (key, value) in _sent_telemetry:
         return
-    _sent_telemetry.add((key, value))
+    _sent_telemetry[(key, value)] = None
+    if len(_sent_telemetry) > _TELEMETRY_CACHE_MAX_SIZE:
+        # Evict the oldest signal to keep memory hard-bounded (last=False -> FIFO).
+        _sent_telemetry.popitem(last=False)
 
     try:
         new_config = ws.config.copy().with_user_agent_extra(key, value)

--- a/src/databricks/labs/dqx/telemetry.py
+++ b/src/databricks/labs/dqx/telemetry.py
@@ -28,6 +28,15 @@ _TELEMETRY_TIMEOUT_SECONDS = 5
 _sent_telemetry: set[tuple[str, str]] = set()
 
 
+def reset_telemetry_cache() -> None:
+    """Clear the per-process telemetry dedup cache so previously sent signals can be sent again.
+
+    Telemetry is deduplicated per process (each *(key, value)* is sent at most once). This resets that
+    state; mainly useful for tests that assert on send behavior in isolation.
+    """
+    _sent_telemetry.clear()
+
+
 def log_telemetry(ws: WorkspaceClient, key: str, value: str) -> None:
     """
     Trace specific telemetry information in the Databricks workspace by setting user agent extra info.

--- a/src/databricks/labs/dqx/telemetry.py
+++ b/src/databricks/labs/dqx/telemetry.py
@@ -7,33 +7,65 @@ from io import StringIO
 from collections.abc import Callable
 from pyspark.sql import DataFrame, SparkSession
 from databricks.sdk import WorkspaceClient
-from databricks.sdk.errors import DatabricksError
 
 
 logger = logging.getLogger(__name__)
+
+# Bound the control-plane ping so a workspace brownout cannot stall the caller. The SDK's default
+# retry window is 300s; on repeated 503s it blocks for that long and then raises TimeoutError. A few
+# seconds is ample for a healthy workspace, and telemetry is best-effort so giving up early is fine.
+_TELEMETRY_TIMEOUT_SECONDS = 5
+
+# Telemetry is a user-agent adoption signal (which features/checks/streaming/DLT are used), not an
+# invocation counter, so each (key, value) only needs to be sent once per process. Caching the pairs
+# already sent means the ping fires at most once per signal instead of once per check per micro-batch
+# — bounding both the load on the control plane and the number of times a brownout can stall a caller.
+#
+# No lock: set membership/add are atomic under the GIL and add is idempotent, so the cache can never be
+# corrupted. The only thing a lock would add is preventing a rare check-then-add race under concurrent
+# callers (e.g. overlapping foreachBatch micro-batches) from firing one duplicate ping — harmless for a
+# best-effort, timeout-bounded call, so it isn't worth the extra machinery.
+_sent_telemetry: set[tuple[str, str]] = set()
 
 
 def log_telemetry(ws: WorkspaceClient, key: str, value: str) -> None:
     """
     Trace specific telemetry information in the Databricks workspace by setting user agent extra info.
 
+    Best-effort: telemetry must never affect the data path. Each *(key, value)* is sent at most once
+    per process, the control-plane call is bounded by a short timeout, and any failure is swallowed
+    (logged at debug) so telemetry can never block for long or propagate an exception into user code.
+
     Args:
         ws: WorkspaceClient
         key: telemetry key to log
         value: telemetry value to log
     """
-    new_config = ws.config.copy().with_user_agent_extra(key, value)
-    logger.debug(f"Added User-Agent extra {key}={value}")
-
-    # Recreate the WorkspaceClient from the same type to preserve type information
-    ws = type(ws)(config=new_config)
+    # Deduplicate per process: skip if this signal was already sent (or attempted). Marking on attempt
+    # (not only on success) means at most one control-plane call per signal per process, so a brownout
+    # cannot re-stall the caller on every subsequent micro-batch.
+    if (key, value) in _sent_telemetry:
+        return
+    _sent_telemetry.add((key, value))
 
     try:
+        new_config = ws.config.copy().with_user_agent_extra(key, value)
+        # Cap the retry window (default 300s) and per-request time so a control-plane brownout gives
+        # up in seconds instead of stalling the caller for minutes.
+        new_config.retry_timeout_seconds = _TELEMETRY_TIMEOUT_SECONDS
+        new_config.http_timeout_seconds = _TELEMETRY_TIMEOUT_SECONDS
+        logger.debug(f"Added User-Agent extra {key}={value}")
+
+        # Recreate the WorkspaceClient from the same type to preserve type information
+        ws = type(ws)(config=new_config)
+
         # use api that works on all workspaces and clusters including group assigned clusters
         ws.clusters.select_spark_version()
-    except DatabricksError as e:
-        # support local execution
-        logger.debug(f"Databricks workspace is not available: {e}")
+    except Exception as e:
+        # Broad on purpose: telemetry is best-effort and must never propagate into the data path.
+        # Covers workspace unavailability (local execution), SDK retry-exhaustion TimeoutError, and any
+        # other failure.
+        logger.debug(f"Telemetry not sent for {key}={value}: {e}")
 
 
 def telemetry_logger(key: str, value: str, workspace_client_attr: str = "ws") -> Callable:
@@ -89,6 +121,18 @@ def log_dataframe_telemetry(ws: WorkspaceClient, spark: SparkSession, df: DataFr
     Returns:
         None
     """
+    # Wrap the whole body: telemetry must never propagate into user code. log_telemetry and the plan
+    # helpers are individually guarded, but df.isStreaming can itself raise (see issue #1001), so the
+    # outer guard honors the "never throw" contract regardless of which step fails.
+    try:
+        _log_dataframe_telemetry(ws, spark, df)
+    except Exception as e:
+        # Best-effort: log and continue so a telemetry failure never breaks the data path.
+        logger.debug(f"DataFrame telemetry not logged: {e}")
+
+
+def _log_dataframe_telemetry(ws: WorkspaceClient, spark: SparkSession, df: DataFrame) -> None:
+    """Unguarded body of *log_dataframe_telemetry*; the caller wraps it so it can never throw."""
     log_telemetry(ws, "streaming", str(df.isStreaming).lower())
     log_telemetry(ws, "dlt", str(is_dlt_pipeline(spark)).lower())
 

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -2,7 +2,6 @@ from unittest.mock import Mock, PropertyMock
 
 import pytest
 
-import databricks.labs.dqx.telemetry as telemetry_module
 from databricks.labs.dqx.telemetry import (
     is_dlt_pipeline,
     get_tables_from_spark_plan,
@@ -10,6 +9,7 @@ from databricks.labs.dqx.telemetry import (
     get_spark_plan_as_string,
     log_telemetry,
     log_dataframe_telemetry,
+    reset_telemetry_cache,
 )
 
 
@@ -348,12 +348,12 @@ class _FakeWorkspaceClient:
 @pytest.fixture(autouse=True)
 def _reset_telemetry_state():
     """Reset the process-level dedup cache and fake-client state around each test."""
-    telemetry_module._sent_telemetry.clear()
+    reset_telemetry_cache()
     _FakeWorkspaceClient.call_count = 0
     _FakeWorkspaceClient.raise_exc = None
     _FakeWorkspaceClient.last_config = None
     yield
-    telemetry_module._sent_telemetry.clear()
+    reset_telemetry_cache()
 
 
 def test_log_telemetry_sends_once_and_sets_bounded_timeouts():
@@ -362,9 +362,10 @@ def test_log_telemetry_sends_once_and_sets_bounded_timeouts():
     assert _FakeWorkspaceClient.call_count == 1
     cfg = _FakeWorkspaceClient.last_config
     assert ("check", "is_not_null") in cfg.user_agent_extra
-    # The control-plane ping must be bounded so a brownout cannot stall the caller for minutes.
-    assert cfg.retry_timeout_seconds == telemetry_module._TELEMETRY_TIMEOUT_SECONDS
-    assert cfg.http_timeout_seconds == telemetry_module._TELEMETRY_TIMEOUT_SECONDS
+    # The control-plane ping must be bounded (a few seconds) so a brownout cannot stall the caller
+    # for minutes; assert the behavior (a small positive timeout) rather than the exact constant.
+    assert cfg.retry_timeout_seconds is not None and 0 < cfg.retry_timeout_seconds <= 60
+    assert cfg.http_timeout_seconds is not None and 0 < cfg.http_timeout_seconds <= 60
 
 
 def test_log_telemetry_deduplicates_same_key_value():

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -422,3 +422,27 @@ def test_log_dataframe_telemetry_never_throws_when_is_streaming_raises():
     # Must not raise, and must not reach the control-plane ping (it fails before any log_telemetry send).
     log_dataframe_telemetry(_FakeWorkspaceClient(), spark, df)
     assert _FakeWorkspaceClient.call_count == 0
+
+
+def test_log_telemetry_cache_is_bounded_and_evicts_oldest(monkeypatch):
+    """The dedup cache is hard-bounded: past the cap the oldest signal is evicted (FIFO), so it can be
+    re-sent later. Prevents unbounded growth for a long-lived process reading ever-new inputs."""
+    monkeypatch.setattr("databricks.labs.dqx.telemetry._TELEMETRY_CACHE_MAX_SIZE", 3)
+    ws = _FakeWorkspaceClient()
+
+    # Fill to capacity with distinct signals (each pings once).
+    for i in range(3):
+        log_telemetry(ws, "input_table", f"h{i}")
+    assert _FakeWorkspaceClient.call_count == 3
+
+    # One more distinct signal exceeds the cap and evicts the oldest ("h0").
+    log_telemetry(ws, "input_table", "h3")
+    assert _FakeWorkspaceClient.call_count == 4
+
+    # The evicted "h0" is no longer cached, so re-sending it pings again (proves eviction happened).
+    log_telemetry(ws, "input_table", "h0")
+    assert _FakeWorkspaceClient.call_count == 5
+
+    # A still-cached signal ("h3") is not re-sent.
+    log_telemetry(ws, "input_table", "h3")
+    assert _FakeWorkspaceClient.call_count == 5

--- a/tests/unit/test_telemetry.py
+++ b/tests/unit/test_telemetry.py
@@ -1,8 +1,15 @@
+from unittest.mock import Mock, PropertyMock
+
+import pytest
+
+import databricks.labs.dqx.telemetry as telemetry_module
 from databricks.labs.dqx.telemetry import (
     is_dlt_pipeline,
     get_tables_from_spark_plan,
     get_paths_from_spark_plan,
     get_spark_plan_as_string,
+    log_telemetry,
+    log_dataframe_telemetry,
 )
 
 
@@ -285,3 +292,132 @@ def test_get_paths_with_unicode_paths():
     # Should handle gracefully
     paths = get_paths_from_spark_plan(plan_with_unicode_paths)
     assert isinstance(paths, set), "Expected set return type with unicode paths"
+
+
+# --- log_telemetry: best-effort, non-blocking, deduplicated ------------------------------------
+
+
+class _FakeConfig:
+    """Minimal stand-in for databricks.sdk.config.Config supporting the calls log_telemetry makes."""
+
+    def __init__(self):
+        self.user_agent_extra: list[tuple[str, str]] = []
+        self.retry_timeout_seconds = None
+        self.http_timeout_seconds = None
+
+    def copy(self) -> "_FakeConfig":
+        clone = _FakeConfig()
+        clone.user_agent_extra = list(self.user_agent_extra)
+        return clone
+
+    def with_user_agent_extra(self, key: str, value: str) -> "_FakeConfig":
+        self.user_agent_extra.append((key, value))
+        return self
+
+
+class _FakeClusters:
+    def __init__(self, on_call):
+        self._on_call = on_call
+
+    def select_spark_version(self):
+        self._on_call()
+
+
+class _FakeWorkspaceClient:
+    """Re-instantiable fake so `type(ws)(config=new_config)` in log_telemetry works without a network."""
+
+    call_count = 0
+    raise_exc: BaseException | None = None
+    last_config: _FakeConfig | None = None
+
+    def __init__(self, config: _FakeConfig | None = None):
+        self.config = config or _FakeConfig()
+
+    @property
+    def clusters(self) -> _FakeClusters:
+        return _FakeClusters(self._record_call)
+
+    def _record_call(self):
+        type(self).call_count += 1
+        type(self).last_config = self.config
+        exc = type(self).raise_exc
+        if exc is not None:
+            raise exc
+
+
+@pytest.fixture(autouse=True)
+def _reset_telemetry_state():
+    """Reset the process-level dedup cache and fake-client state around each test."""
+    telemetry_module._sent_telemetry.clear()
+    _FakeWorkspaceClient.call_count = 0
+    _FakeWorkspaceClient.raise_exc = None
+    _FakeWorkspaceClient.last_config = None
+    yield
+    telemetry_module._sent_telemetry.clear()
+
+
+def test_log_telemetry_sends_once_and_sets_bounded_timeouts():
+    log_telemetry(_FakeWorkspaceClient(), "check", "is_not_null")
+
+    assert _FakeWorkspaceClient.call_count == 1
+    cfg = _FakeWorkspaceClient.last_config
+    assert ("check", "is_not_null") in cfg.user_agent_extra
+    # The control-plane ping must be bounded so a brownout cannot stall the caller for minutes.
+    assert cfg.retry_timeout_seconds == telemetry_module._TELEMETRY_TIMEOUT_SECONDS
+    assert cfg.http_timeout_seconds == telemetry_module._TELEMETRY_TIMEOUT_SECONDS
+
+
+def test_log_telemetry_deduplicates_same_key_value():
+    ws = _FakeWorkspaceClient()
+    for _ in range(5):
+        log_telemetry(ws, "check", "is_not_null")
+
+    # Same (key, value) sent five times -> control plane pinged at most once per process.
+    assert _FakeWorkspaceClient.call_count == 1
+
+
+def test_log_telemetry_distinct_keys_each_send_once():
+    ws = _FakeWorkspaceClient()
+    log_telemetry(ws, "check", "is_not_null")
+    log_telemetry(ws, "check", "is_in_range")
+    log_telemetry(ws, "streaming", "true")
+    log_telemetry(ws, "check", "is_not_null")  # duplicate of the first
+
+    assert _FakeWorkspaceClient.call_count == 3
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        TimeoutError("Timed out after 0:05:00"),  # the exact SDK retry-exhaustion case from issue #1355
+        RuntimeError("boom"),
+        ValueError("unexpected"),
+    ],
+)
+def test_log_telemetry_never_propagates_exceptions(exc):
+    _FakeWorkspaceClient.raise_exc = exc
+    # Must not raise: telemetry is best-effort and must never reach the data path.
+    log_telemetry(_FakeWorkspaceClient(), "check", "is_not_null")
+    assert _FakeWorkspaceClient.call_count == 1
+
+
+def test_log_telemetry_failed_send_is_not_retried():
+    _FakeWorkspaceClient.raise_exc = TimeoutError("Timed out")
+    ws = _FakeWorkspaceClient()
+    for _ in range(3):
+        log_telemetry(ws, "check", "is_not_null")
+
+    # Marked sent on attempt (not only on success), so a brownout cannot re-stall every micro-batch.
+    assert _FakeWorkspaceClient.call_count == 1
+
+
+def test_log_dataframe_telemetry_never_throws_when_is_streaming_raises():
+    """log_dataframe_telemetry must honor its 'never throw' contract even if df.isStreaming raises
+    (the failure mode from issue #1001) — the outer guard must swallow it and continue."""
+    df = Mock()
+    type(df).isStreaming = PropertyMock(side_effect=RuntimeError("Spark Connect: isStreaming unavailable"))
+
+    spark = DummySparkSession(DummySparkConf(value=None))
+    # Must not raise, and must not reach the control-plane ping (it fails before any log_telemetry send).
+    log_dataframe_telemetry(_FakeWorkspaceClient(), spark, df)
+    assert _FakeWorkspaceClient.call_count == 0


### PR DESCRIPTION
## Changes

Fixes #1355. Telemetry could terminate Structured Streaming jobs: `log_telemetry` made a **blocking per-check** control-plane call (`select_spark_version`, GET `/api/2.1/clusters/spark-versions`) guarded only by `except DatabricksError`. On a control-plane brownout the SDK retried for its ~300s window and then raised a builtin **`TimeoutError`**, which is *not* a `DatabricksError` — so it escaped the guard, propagated through `foreachBatch`, and failed the batch, **once per micro-batch, forever**.

This makes telemetry strictly best-effort — it can never throw, never block for long, and never fire more than once per signal — implementing the two agreed items from the issue thread plus a small bounded-timeout:

- **Never throw.** Broaden the guard `except DatabricksError` → `except Exception` (debug-logged). Also wrap `log_dataframe_telemetry`'s whole body so a raising `df.isStreaming` (the #1001 failure mode) can't propagate either, honoring its "never throw" docstring.
- **Deduplicate per process.** Cache each `(key, value)` so the ping fires **at most once per signal per process**, not once per check per micro-batch. Telemetry is a user-agent *adoption* signal (which features/checks/streaming/DLT are used), not an invocation counter, so dedup preserves exactly the signal we care about while removing the repeated blocking calls.
- **Bound the call.** Cap `retry_timeout_seconds` / `http_timeout_seconds` (5s) on the copied config so a brownout gives up in seconds instead of stalling the caller for minutes.

No background threads, no opt-out env var, and no `with_user_agent_extra` piggyback — see the "not done" tradeoffs below (all consistent with the [issue discussion](https://github.com/databrickslabs/dqx/issues/1355#issuecomment-)).

### Tradeoffs (deliberate)

- **Dedup marks a signal "sent" on *attempt*, not only on success.** This guarantees at most one control-plane call per signal per process, so a brownout can't re-stall every micro-batch. The cost: if the *very first* attempt for a signal hits a transient failure, that one signal is not retried for the life of the process (silently lost). Accepted — bounding the stall matters more than a single best-effort signal.
- **The dedup cache is process-global and hard-bounded (FIFO).** Most keys are naturally bounded (check names, `streaming`/`dlt`, `workflow`), but `input_table`/`input_path` add one small hashed entry per *distinct* input, so a very long-lived driver reading an ever-growing set of tables could otherwise grow it without limit. The cache is an `OrderedDict` capped at 10,000 entries, evicting oldest-first when over capacity. The cap is far above realistic distinct-input counts (thousands ≈ low-single-digit MB), so eviction only triggers for pathological workloads and merely lets an evicted signal be re-sent once later — harmless for best-effort telemetry.
- **No lock on the dedup cache.** Dict membership / insert / `popitem` are atomic under the GIL, so the cache can never be corrupted; a concurrent check-then-add race can at most fire one duplicate ping, and since eviction only runs when the cache is over capacity (never near-empty) a concurrent eviction can at most drop one extra entry — both harmless for a best-effort call, so a lock isn't worth the machinery.
- **Equal timeouts (`retry` == `http` == 5s).** Leaves no room for a retry within the window, so a slow-but-healthy response (>5s tail) is dropped. Intentional: the goal is to give up fast, and 5s is ample for a healthy control plane.

**Not done (per the issue discussion):** bounded-timeout-only tuning knob, `with_user_agent_extra` piggyback (the streaming path makes no SDK calls to piggyback on, so it would send *no* telemetry for exactly the usage we want to see), and a telemetry opt-out env var (we rely on adoption telemetry to improve DQX).

### Linked issues

Resolves #1355. Related prior reports of telemetry side effects: #1001, #1073.

### Tests

- [ ] manually tested
- [x] added unit tests
- [ ] added integration tests
- [ ] added end-to-end tests

