### PR TITLE
docs: add MCP server to README key capabilities

### DIFF
--- a/.github/scripts/deploy-docs.sh
+++ b/.github/scripts/deploy-docs.sh
@@ -130,6 +130,15 @@ if [[ ! -d "${WORKTREE_DIR}" ]]; then
       git commit --allow-empty -m "Initialize gh-pages"
     )
   fi
+else
+  # Worktree already exists. Reset it to origin/gh-pages so the new deploy
+  # commit is a clean fast-forward and the append-only push can't be rejected
+  # by local drift or a leftover un-pushed commit from a previous run. Guarded
+  # on origin/gh-pages existing (it may not if a prior bootstrap never pushed).
+  if git rev-parse --verify --quiet origin/gh-pages > /dev/null; then
+    echo "==> Resetting existing gh-pages worktree to origin/gh-pages"
+    git -C "${WORKTREE_DIR}" reset --hard origin/gh-pages
+  fi
 fi
 
 # --- Sync build into the gh-pages worktree -----------------------------------

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Simplified Data Quality checking at Scale for PySpark Workloads on streaming and
 - **Actions and alerting** — automatically send Slack, Microsoft Teams, or generic webhook alerts and/or fail the pipeline when summary metrics cross a threshold.
 - **Flexible checks storage** — save and load quality rules from YAML/JSON files, Unity Catalog tables, Volumes, or Lakebase (PostgreSQL).
 - **DQX Studio** — browser-based no-code UI for authoring, reviewing, running, and monitoring quality rules, deployed as a Databricks App.
+- **MCP server** — Model Context Protocol server that exposes DQX as tools for AI agents (Claude, Genie, Cursor, and others), deployed as a Databricks App with on-behalf-of authentication so data access follows Unity Catalog permissions.
 - **Data format agnostic & streaming support** — works with PySpark DataFrames and applies checks to both batch and Spark Structured Streaming (including Lakeflow Pipelines / DLT) using the same API.
 
 # 📖 Documentation


### PR DESCRIPTION
## Changes

Two docs-related changes:

1. **README** — adds the **MCP server** to the "Key capabilities" list. The MCP (Model Context Protocol) server shipped in 0.16.0 ([#1252](https://github.com/databrickslabs/dqx/issues/1252)) but was never added to the README, so the capabilities list was incomplete. New bullet, placed next to DQX Studio (the other Databricks App surface).

2. **`deploy-docs.sh`** — make the gh-pages deploy script idempotent across repeat runs. Previously it only synced the `gh-pages` worktree to `origin/gh-pages` on first run (when the worktree was created); on later runs it committed on top of whatever the local `gh-pages` branch happened to be. If `origin/gh-pages` had advanced or a prior run left an un-pushed commit, the append-only push was rejected as non-fast-forward and left the local branch diverged. The script now resets the existing worktree to `origin/gh-pages` before syncing the build, so the deploy commit is always a clean fast-forward.

No functional changes to the library.

This pull request and its description were written by Isaac.