### PR TITLE
feat(app): dqx-core compatible rule loading + backend clean up

### DIFF
--- a/app/AGENTS.md
+++ b/app/AGENTS.md
@@ -74,8 +74,9 @@ but is protected transitively by the instance-level guard.
  │   ├── dq_quarantine_records        (Delta) invalid rows captured by runs
  │   ├── dq_metrics                   (Delta) per-run quality metrics for trend tracking
  │   ├── dq_app_settings              (OLTP*) key/value app configuration
- │   ├── dq_quality_rules             (OLTP*) active/approved rules
- │   ├── dq_quality_rules_history     (OLTP*) rule change audit log
+ │   ├── dq_resolved_rules             (OLTP*) active/approved rules
+ │   ├── dq_rules_core                 (VIEW, Lakebase) dqx-core-compatible read view over approved dq_resolved_rules — external pipelines load it via DQEngine.load_checks(LakebaseChecksStorageConfig)
+ │   ├── dq_resolved_rules_history     (OLTP*) rule change audit log
  │   ├── dq_role_mappings             (OLTP*) role → workspace group mappings (RBAC)
  │   ├── dq_comments                  (OLTP*) comment threads on rules/runs
  │   ├── dq_schedule_configs          (OLTP*) per-schedule config (cron/interval, target rules)
@@ -88,8 +89,8 @@ but is protected transitively by the instance-level guard.
 Lakebase project (when enabled, default `lakebase_project_id` = `dqx-studio-db`):
  └── databricks_postgres              (database — always-present admin DB; no per-app DB provisioned)
      └── dqx_studio                   (schema — created by PgMigrationRunner on first start; configurable via DQX_LAKEBASE_SCHEMA)
-         ├── dq_app_settings, dq_role_mappings, dq_quality_rules,
-         │   dq_quality_rules_history, dq_comments, dq_schedule_configs,
+         ├── dq_app_settings, dq_role_mappings, dq_resolved_rules,
+         │   dq_resolved_rules_history, dq_comments, dq_schedule_configs,
          │   dq_schedule_configs_history, dq_schedule_runs
          └── dq_migrations             (Postgres migration version tracker)
 ```
@@ -511,7 +512,7 @@ choice is driven entirely by `databricks.yml`:
 | Backend | Tables | Why |
 |---------|--------|-----|
 | **Delta Lake** (always) | `dq_validation_runs`, `dq_profiling_results`, `dq_quarantine_records`, `dq_metrics` | Spark task runner writes these; high-volume append-mostly; columnar reads. |
-| **Lakebase Postgres** *(default — opt-out via `lakebase_endpoint="-"`)* | `dq_app_settings`, `dq_role_mappings`, `dq_quality_rules`, `dq_quality_rules_history`, `dq_comments`, `dq_schedule_configs`, `dq_schedule_configs_history`, `dq_schedule_runs` | Low-latency point reads/writes from FastAPI request handlers; row-level upserts; primary-key/foreign-key semantics. |
+| **Lakebase Postgres** *(default — opt-out via `lakebase_endpoint="-"`)* | `dq_app_settings`, `dq_role_mappings`, `dq_resolved_rules`, `dq_resolved_rules_history`, `dq_comments`, `dq_schedule_configs`, `dq_schedule_configs_history`, `dq_schedule_runs` | Low-latency point reads/writes from FastAPI request handlers; row-level upserts; primary-key/foreign-key semantics. |
 
 When Lakebase is **disabled** (no `lakebase_endpoint` set), the OLTP
 tables fall back to Delta — `MigrationRunner` runs both
@@ -549,7 +550,7 @@ per `_RETENTION_INTERVAL_HOURS` (24h). Two knobs, both stored in
 
 | Setting key                  | Default | Tables affected |
 |------------------------------|--------:|-----------------|
-| `retention_days`             | 90      | `dq_validation_runs`, `dq_profiling_results`, `dq_metrics`, plus the OLTP history tables (`dq_quality_rules_history`, `dq_schedule_configs_history`). Picked to match what trend dashboards expect. |
+| `retention_days`             | 90      | `dq_validation_runs`, `dq_profiling_results`, `dq_metrics`, plus the OLTP history tables (`dq_resolved_rules_history`, `dq_schedule_configs_history`). Picked to match what trend dashboards expect. |
 | `quarantine_retention_days`  | 30      | `dq_quarantine_records` only. Tighter because that table holds the full source row payload (PII surface). |
 
 Both resolvers share a `_RETENTION_DAYS_MIN = 7` floor so a

--- a/app/src/databricks_labs_dqx_app/backend/migrations/__init__.py
+++ b/app/src/databricks_labs_dqx_app/backend/migrations/__init__.py
@@ -85,7 +85,7 @@ Two status families intentionally use different casing:
   (``RUNNING``/``SUCCESS``/``FAILED``/``CANCELED``). These mirror the
   Databricks Jobs SDK ``life_cycle_state`` / ``result_state`` values
   that are passed straight through ``RunStatusOut`` to the frontend.
-- **App-domain workflow** (``dq_quality_rules.status``,
+- **App-domain workflow** (``dq_resolved_rules.status``,
   ``dq_schedule_runs.status``) — lowercase. These are pure DQX
   vocabulary (``draft``/``approved``, ``pending``/``partial_failure``)
   with no SDK counterpart.
@@ -255,7 +255,7 @@ class Migration:
 # - CHECK constraints ARE enforced — picking the right value-set on
 #   day one is cheap; loosening later is just an ALTER TABLE.
 # - ``VARIANT`` (DBR 15.3+ / serverless) replaces ad-hoc JSON-in-string
-#   for the largest blob columns (``dq_quality_rules.check``,
+#   for the largest blob columns (``dq_resolved_rules.check``,
 #   ``dq_quarantine_records.row_data``/``errors``).
 # - Run-lifecycle ``status`` columns use UPPERCASE values to mirror the
 #   Databricks Jobs SDK; app-domain ``status`` columns use lowercase.

--- a/app/src/databricks_labs_dqx_app/backend/migrations/postgres.py
+++ b/app/src/databricks_labs_dqx_app/backend/migrations/postgres.py
@@ -131,8 +131,7 @@ PG_MIGRATIONS: list[PgMigration] = [
             # with the table-agnostic registry ``dq_rules``: these are the
             # rules resolved/materialized against a concrete ``table_fqn``.
             # ``registry_rule_id``/``registry_version``/``applied_rule_id``
-            # are provenance columns (Phase 3A, see docs/superpowers/specs/
-            # 2026-07-02-rules-registry-design.md §3.1): when a row was
+            # are Rules Registry provenance columns: when a row was
             # materialized from a Rules Registry application, they point
             # back at the source ``dq_rules`` row, the published version
             # substituted, and the ``dq_applied_rules`` link — all NULL for
@@ -156,7 +155,11 @@ PG_MIGRATIONS: list[PgMigration] = [
             "  registry_rule_id  TEXT,"
             "  registry_version  INTEGER,"
             "  applied_rule_id   TEXT,"
-            "  rule_fingerprint  TEXT,"
+            # NOT NULL: every writer (RulesCatalogService.save/update_rule,
+            # Materializer) sets this via compute_rule_fingerprint. Enforcing it
+            # keeps the dq_rules_core set-fingerprint aggregation exact — a NULL
+            # would be silently skipped by string_agg and weaken uniqueness.
+            "  rule_fingerprint  TEXT NOT NULL,"
             "  created_by TEXT,"
             "  created_at TIMESTAMPTZ,"
             "  updated_by TEXT,"
@@ -766,7 +769,10 @@ PG_MIGRATIONS: list[PgMigration] = [
             f"  FROM {_S}.dq_resolved_rules WHERE status = 'approved'"
             "), set_fp AS ("
             "  SELECT table_fqn, encode(sha256(convert_to("
-            "    '[' || string_agg('\"' || rule_fingerprint || '\"', ', ' ORDER BY rule_fingerprint) || ']',"
+            # COLLATE "C" forces codepoint ordering so the hash byte-matches
+            # dqx-core's compute_rule_set_fingerprint (Python sorts by codepoint),
+            # independent of the database's default collation.
+            "    '[' || string_agg('\"' || rule_fingerprint || '\"', ', ' ORDER BY rule_fingerprint COLLATE \"C\") || ']',"
             "    'UTF8')), 'hex') AS rule_set_fingerprint "
             "  FROM approved GROUP BY table_fqn"
             ") SELECT "

--- a/app/src/databricks_labs_dqx_app/backend/migrations/postgres.py
+++ b/app/src/databricks_labs_dqx_app/backend/migrations/postgres.py
@@ -126,19 +126,27 @@ PG_MIGRATIONS: list[PgMigration] = [
             "  updated_by    TEXT"
             ");"
             # ----------------------------------------------------------
-            # dq_quality_rules — active rule catalog. ``registry_rule_id``/
-            # ``registry_version``/``applied_rule_id`` are provenance
-            # columns (Phase 3A, see docs/superpowers/specs/2026-07-02-
-            # rules-registry-design.md §3.1): when a row was materialized
-            # from a Rules Registry application, they point back at the
-            # source ``dq_rules`` row, the published version substituted,
-            # and the ``dq_applied_rules`` link — all NULL for rules
-            # authored directly against a table (unchanged legacy path).
-            # ``source='registry'`` marks a materialized row (Phase 3C
-            # ``Materializer``); the runner ignores ``source`` entirely so
-            # this is purely provenance for the UI/audit trail.
+            # dq_resolved_rules — active (resolved) per-table rule catalog.
+            # Renamed from ``dq_quality_rules`` so the name is not confused
+            # with the table-agnostic registry ``dq_rules``: these are the
+            # rules resolved/materialized against a concrete ``table_fqn``.
+            # ``registry_rule_id``/``registry_version``/``applied_rule_id``
+            # are provenance columns (Phase 3A, see docs/superpowers/specs/
+            # 2026-07-02-rules-registry-design.md §3.1): when a row was
+            # materialized from a Rules Registry application, they point
+            # back at the source ``dq_rules`` row, the published version
+            # substituted, and the ``dq_applied_rules`` link — all NULL for
+            # rules authored directly against a table (unchanged legacy
+            # path). ``source='registry'`` marks a materialized row (Phase
+            # 3C ``Materializer``); the runner ignores ``source`` entirely
+            # so this is purely provenance for the UI/audit trail.
+            # ``rule_fingerprint`` is the dqx-core per-rule SHA-256
+            # (``compute_rule_fingerprint``) written by every writer; it
+            # powers the ``dq_rules_core`` compatibility view (below) so
+            # external pipelines can load these rules with the standard
+            # ``DQEngine.load_checks``.
             # ----------------------------------------------------------
-            f"CREATE TABLE IF NOT EXISTS {_S}.dq_quality_rules ("
+            f"CREATE TABLE IF NOT EXISTS {_S}.dq_resolved_rules ("
             "  rule_id           TEXT PRIMARY KEY,"
             "  table_fqn         TEXT NOT NULL,"
             '  "check"           JSONB NOT NULL,'
@@ -148,24 +156,25 @@ PG_MIGRATIONS: list[PgMigration] = [
             "  registry_rule_id  TEXT,"
             "  registry_version  INTEGER,"
             "  applied_rule_id   TEXT,"
+            "  rule_fingerprint  TEXT,"
             "  created_by TEXT,"
             "  created_at TIMESTAMPTZ,"
             "  updated_by TEXT,"
             "  updated_at TIMESTAMPTZ,"
-            "  CONSTRAINT chk_dq_quality_rules_status "
+            "  CONSTRAINT chk_dq_resolved_rules_status "
             f"    CHECK (status IN ({RuleStatus.sql_in_list()})),"
-            "  CONSTRAINT chk_dq_quality_rules_source "
+            "  CONSTRAINT chk_dq_resolved_rules_source "
             f"    CHECK (source IN ({RuleSource.sql_in_list()}))"
             ");"
             # Two read-paths dominate: by table_fqn (rules-list page) and
             # by status filter (review queue). One composite index covers
             # both since Postgres can use a leading-column-only scan.
-            f"CREATE INDEX IF NOT EXISTS idx_dq_quality_rules_table_status "
-            f"  ON {_S}.dq_quality_rules (table_fqn, status);"
+            f"CREATE INDEX IF NOT EXISTS idx_dq_resolved_rules_table_status "
+            f"  ON {_S}.dq_resolved_rules (table_fqn, status);"
             # ----------------------------------------------------------
-            # dq_quality_rules_history — append-only audit trail.
+            # dq_resolved_rules_history — append-only audit trail.
             # ----------------------------------------------------------
-            f"CREATE TABLE IF NOT EXISTS {_S}.dq_quality_rules_history ("
+            f"CREATE TABLE IF NOT EXISTS {_S}.dq_resolved_rules_history ("
             "  history_id  BIGSERIAL PRIMARY KEY,"
             "  rule_id     TEXT,"
             "  table_fqn   TEXT NOT NULL,"
@@ -178,10 +187,10 @@ PG_MIGRATIONS: list[PgMigration] = [
             "  changed_by  TEXT,"
             "  changed_at  TIMESTAMPTZ"
             ");"
-            f"CREATE INDEX IF NOT EXISTS idx_dq_quality_rules_history_rule_changed_at "
-            f"  ON {_S}.dq_quality_rules_history (rule_id, changed_at DESC);"
-            f"CREATE INDEX IF NOT EXISTS idx_dq_quality_rules_history_table_changed_at "
-            f"  ON {_S}.dq_quality_rules_history (table_fqn, changed_at DESC);"
+            f"CREATE INDEX IF NOT EXISTS idx_dq_resolved_rules_history_rule_changed_at "
+            f"  ON {_S}.dq_resolved_rules_history (rule_id, changed_at DESC);"
+            f"CREATE INDEX IF NOT EXISTS idx_dq_resolved_rules_history_table_changed_at "
+            f"  ON {_S}.dq_resolved_rules_history (table_fqn, changed_at DESC);"
             # ----------------------------------------------------------
             # dq_role_mappings — RBAC.
             # ----------------------------------------------------------
@@ -265,7 +274,7 @@ PG_MIGRATIONS: list[PgMigration] = [
             # ``user_metadata`` (see ``label_definitions``/Phase 1),
             # same as arbitrary free-text tags. ``rule_id`` is a
             # hex-string id generated in Python (``uuid4().hex[:16]``,
-            # matching ``dq_quality_rules.rule_id`` / ``dq_comments.comment_id``)
+            # matching ``dq_resolved_rules.rule_id`` / ``dq_comments.comment_id``)
             # stored as TEXT rather than the native ``UUID`` type, so all
             # entity ids share one representation across the schema.
             # ----------------------------------------------------------
@@ -334,7 +343,7 @@ PG_MIGRATIONS: list[PgMigration] = [
             # ----------------------------------------------------------
             # dq_rules_history — append-only audit trail for the
             # registry rule lifecycle (create/update/status transitions/
-            # delete), mirroring ``dq_quality_rules_history``'s shape.
+            # delete), mirroring ``dq_resolved_rules_history``'s shape.
             # ----------------------------------------------------------
             f"CREATE TABLE IF NOT EXISTS {_S}.dq_rules_history ("
             "  history_id    BIGSERIAL PRIMARY KEY,"
@@ -722,6 +731,56 @@ PG_MIGRATIONS: list[PgMigration] = [
             "  model        TEXT,"
             "  updated_at   TIMESTAMPTZ"
             ");"
+            # ----------------------------------------------------------
+            # dq_rules_core — dqx-core-compatible READ view over the
+            # APPROVED rules in ``dq_resolved_rules``. It reshapes Studio's
+            # storage into exactly the columns dqx-core's
+            # ``LakebaseChecksStorageHandler`` reads, so external pipelines
+            # can load Studio-authored rules with the standard API:
+            #
+            #   engine.load_checks(LakebaseChecksStorageConfig(
+            #       location="<cat>.{schema}.dq_rules_core",
+            #       instance_name="<lakebase-instance>",
+            #       run_config_name="<table_fqn>"))
+            #
+            # Column mapping: ``run_config_name`` <- ``table_fqn``; ``check``
+            # <- the INNER ``{{function, arguments, for_each_column}}`` object
+            # (Studio packs the whole rule into the ``"check"`` JSONB, dqx-core
+            # wants only the inner check); name/criticality/filter/
+            # user_metadata/message_expr are read out of that blob.
+            #
+            # ``rule_set_fingerprint`` is computed here (not stored) as a
+            # GROUP BY over each table's approved rows, so every row of a
+            # ``table_fqn`` shares one value — which is what the loader needs
+            # to select "the latest rule set" and return the whole set. It
+            # reproduces dqx-core's ``compute_rule_set_fingerprint``
+            # (sha256 of the JSON array of sorted per-rule fingerprints) over
+            # the stored ``rule_fingerprint`` values. For rule sets that
+            # contain a ``for_each_column`` check the value may differ from a
+            # core computation that expands the fan-out first — this only
+            # affects the informational fingerprint, never which rules load.
+            # ----------------------------------------------------------
+            f"CREATE OR REPLACE VIEW {_S}.dq_rules_core AS "
+            "WITH approved AS ("
+            "  SELECT rule_id, table_fqn, \"check\", rule_fingerprint, created_at "
+            f"  FROM {_S}.dq_resolved_rules WHERE status = 'approved'"
+            "), set_fp AS ("
+            "  SELECT table_fqn, encode(sha256(convert_to("
+            "    '[' || string_agg('\"' || rule_fingerprint || '\"', ', ' ORDER BY rule_fingerprint) || ']',"
+            "    'UTF8')), 'hex') AS rule_set_fingerprint "
+            "  FROM approved GROUP BY table_fqn"
+            ") SELECT "
+            "  a.\"check\"->>'name'                          AS name,"
+            "  COALESCE(a.\"check\"->>'criticality', 'error') AS criticality,"
+            "  a.\"check\"->'check'                          AS \"check\","
+            "  a.\"check\"->>'filter'                        AS filter,"
+            "  a.table_fqn                                   AS run_config_name,"
+            "  a.\"check\"->'user_metadata'                  AS user_metadata,"
+            "  a.\"check\"->>'message_expr'                  AS message_expr,"
+            "  a.created_at                                  AS created_at,"
+            "  a.rule_fingerprint                            AS rule_fingerprint,"
+            "  s.rule_set_fingerprint                        AS rule_set_fingerprint "
+            "FROM approved a JOIN set_fp s USING (table_fqn)"
         ),
     ),
 ]

--- a/app/src/databricks_labs_dqx_app/backend/models.py
+++ b/app/src/databricks_labs_dqx_app/backend/models.py
@@ -324,7 +324,7 @@ class RuleCatalogEntryOut(BaseModel):
 
 
 class RuleHistoryEntryOut(BaseModel):
-    """One recorded change from the ``dq_quality_rules_history`` audit log.
+    """One recorded change from the ``dq_resolved_rules_history`` audit log.
 
     Backs ``getRuleHistory`` — the per-rule change trail that lets Drafts &
     Review show a previous-vs-proposed diff for a per-table rule draft. Each
@@ -1049,7 +1049,7 @@ class MonitoredTableReviewOut(BaseModel):
     """Response for the submit/approve/reject monitored-table lifecycle routes.
 
     ``table`` carries the binding with its new roll-up status; ``affected_check_count``
-    is how many materialized ``dq_quality_rules`` rows changed status in this
+    is how many materialized ``dq_resolved_rules`` rows changed status in this
     transition (submitted, approved, or rejected respectively).
     """
 

--- a/app/src/databricks_labs_dqx_app/backend/registry_models.py
+++ b/app/src/databricks_labs_dqx_app/backend/registry_models.py
@@ -4,7 +4,7 @@ The registry is the authoring/governance layer described in
 ``docs/superpowers/specs/2026-07-02-rules-registry-design.md`` §3 — reusable,
 versioned, table-agnostic rule *templates* that are later applied to a
 monitored table (mapping slots to real columns) and materialized into
-``dq_quality_rules`` (unchanged runner-facing table).
+``dq_resolved_rules`` (unchanged runner-facing table).
 
 Descriptive metadata — ``name``, ``description``, ``dimension``, ``severity``
 — is intentionally **not** a column on any of these models. It lives as
@@ -115,7 +115,7 @@ class RuleDefinition(BaseModel):
             "Optional custom failure message (a Spark SQL expression string), mirroring "
             "DQRule.message_expr. Threaded through create/update and frozen into each "
             "dq_rule_versions snapshot as part of the definition. Materialized as a "
-            "top-level 'message_expr' key on the rendered dq_quality_rules check when set; "
+            "top-level 'message_expr' key on the rendered dq_resolved_rules check when set; "
             "omitted entirely when None or empty."
         ),
     )
@@ -127,7 +127,7 @@ class RuleDefinition(BaseModel):
             "time. Validated for SQL safety on create/update. Threaded through create/"
             "update and frozen into each dq_rule_versions snapshot as part of the "
             "definition. Materialized as a top-level 'filter' key on the rendered "
-            "dq_quality_rules check when set; omitted entirely when None or empty."
+            "dq_resolved_rules check when set; omitted entirely when None or empty."
         ),
     )
 
@@ -739,7 +739,7 @@ def registry_display_status(status: str, version: int, modified_since_publish: b
 # that decides which output DataFrame a failing row lands in — it is NOT
 # the same axis as the registry's ``severity`` tag (Low/Medium/High/
 # Critical), but the materializer has to pick *some* concrete criticality
-# when it renders a ``dq_quality_rules`` row, so this is the single place
+# when it renders a ``dq_resolved_rules`` row, so this is the single place
 # that conversion happens. The mapping is admin-editable: it lives in the
 # ``value_criticality`` map on the reserved ``severity`` label definition
 # (``dq_app_settings`` / ``label_definitions``), with

--- a/app/src/databricks_labs_dqx_app/backend/routes/v1/monitored_tables.py
+++ b/app/src/databricks_labs_dqx_app/backend/routes/v1/monitored_tables.py
@@ -4,7 +4,7 @@ Layer 2 of the Rules Registry
 (``docs/superpowers/specs/2026-07-02-rules-registry-design.md`` §7): a thin
 binding recording that a table is under active Rules Registry governance,
 plus the live link of applied registry rules and the materializer that
-renders them into ``dq_quality_rules`` (Phase 3C).
+renders them into ``dq_resolved_rules`` (Phase 3C).
 """
 
 from typing import Annotated
@@ -174,7 +174,7 @@ def _apply_snapshot_check_counts(
     B2-25: the overview "# Checks" must agree with the DQ score and the detail
     page. The score is derived from the FROZEN per-version snapshot (via
     ``dq_metrics``), whereas ``MonitoredTableService.list_monitored_tables``
-    counts live ``dq_quality_rules`` rows — a transient set that a
+    counts live ``dq_resolved_rules`` rows — a transient set that a
     re-materialization can (wrongly, pre-Fix-B) drop to zero, so a scored table
     could show 0 checks. Count from the snapshot instead:
 
@@ -383,7 +383,7 @@ def delete_monitored_table(
     the caller is an admin/approver.
 
     TODO(Phase 3C): once the materializer exists, block/handle
-    de-materialization of any ``dq_quality_rules`` rows tied to this
+    de-materialization of any ``dq_resolved_rules`` rows tied to this
     binding's applications before allowing deletion.
     """
     user_email = _current_user_email(obo_ws)
@@ -982,7 +982,7 @@ def remove_applied_rule(
     principal_ids: CurrentPrincipalIds,
     perms: Annotated[PermissionsService, Depends(get_permissions_service)],
 ) -> dict[str, str]:
-    """Remove an applied rule and every ``dq_quality_rules`` row it materialized.
+    """Remove an applied rule and every ``dq_resolved_rules`` row it materialized.
 
     Requires ``APPLY`` on the monitored table unless the caller is an admin/approver.
     """
@@ -1088,11 +1088,11 @@ def set_applied_rule_severity_override(
 # parallel status-mutation implementation, these routes REUSE the per-rule
 # transition path (``RulesCatalogService.set_status`` — the exact call
 # ``routes/v1/rules.py`` submit/approve/reject make) to move each of the
-# binding's materialized ``dq_quality_rules`` rows, so audit/history/version
+# binding's materialized ``dq_resolved_rules`` rows, so audit/history/version
 # semantics are identical for a table's checks whether they were submitted
 # one at a time from Drafts & Review or in bulk from here. The binding's own
 # status is then rolled up from its checks. The scheduler is untouched: it
-# still runs only ``dq_quality_rules`` rows at ``status='approved'``.
+# still runs only ``dq_resolved_rules`` rows at ``status='approved'``.
 # ------------------------------------------------------------------
 
 
@@ -1210,7 +1210,7 @@ def submit_monitored_table(
 ) -> MonitoredTableReviewOut:
     """Submit a monitored table for review.
 
-    Materializes the binding's applied rules into ``dq_quality_rules`` (the
+    Materializes the binding's applied rules into ``dq_resolved_rules`` (the
     UI has already persisted any staged edits via ``saveAppliedRules``), then
     submits every freshly-materialized ``draft`` check for approval — reusing
     the same per-rule transition the Drafts & Review queue uses — and rolls
@@ -1332,7 +1332,7 @@ def approve_monitored_table(
     Reuses the per-rule approve transition so each check's audit trail is
     identical to a hand-approval, then rolls the binding up to ``approved``.
     From here the scheduler picks the checks up (it runs only ``approved``
-    ``dq_quality_rules`` rows).
+    ``dq_resolved_rules`` rows).
 
     Table approval is the ONLY event that bumps the monitored-table version:
     after the binding rolls up to ``approved`` the newly-approved rule set is

--- a/app/src/databricks_labs_dqx_app/backend/routes/v1/registry_rules.py
+++ b/app/src/databricks_labs_dqx_app/backend/routes/v1/registry_rules.py
@@ -538,7 +538,7 @@ def _publish_registry_rule(
     """
     rule = svc.approve(rule_id, approver, rationale=rationale)
     # Activate any Bulk Contract Import pre-staged applications BEFORE
-    # rematerialize so their new dq_quality_rules copies are produced here.
+    # rematerialize so their new dq_resolved_rules copies are produced here.
     _activate_pending_applications(rule_id, approver, apply_rules=apply_rules, pending=pending)
     embeddings.embed_and_store(rule)
     rematerialized = materializer.rematerialize_for_rule(rule_id)
@@ -666,14 +666,14 @@ def approve_registry_rule(
     turn a successful publish into a 500.
 
     Also re-materializes every FOLLOWING (unpinned) application of this
-    rule (design spec §5) so their ``dq_quality_rules`` copies pick up the
+    rule (design spec §5) so their ``dq_resolved_rules`` copies pick up the
     new version — see ``Materializer.rematerialize_for_rule``. PINNED
     applications are untouched by a publish; they only change via a
     direct edit.
 
     Data Products Task 2 re-freeze hook (design spec §3.2 (a)): when
     ``auto_upgrade_without_approval`` is ON, a follower's approved
-    ``dq_quality_rules`` row silently picks up the new content and STAYS
+    ``dq_resolved_rules`` row silently picks up the new content and STAYS
     approved, changing the binding's approved rule set without a table
     re-approval — so each re-materialized binding's current version snapshot
     is re-frozen in place. When auto-upgrade is OFF the changed rows drop to

--- a/app/src/databricks_labs_dqx_app/backend/routes/v1/rules.py
+++ b/app/src/databricks_labs_dqx_app/backend/routes/v1/rules.py
@@ -182,7 +182,7 @@ def get_rule_history(
     """Return a per-table rule's recorded change history (newest first).
 
     Backs the Drafts & Review change-diff popout: reads the
-    ``dq_quality_rules_history`` audit trail so the UI can diff the two most
+    ``dq_resolved_rules_history`` audit trail so the UI can diff the two most
     recent recorded ``check`` payloads (previous vs proposed). Declared BEFORE
     the ``/{table_fqn:path}`` catch-all so the more-specific pattern wins.
 

--- a/app/src/databricks_labs_dqx_app/backend/rule_enums.py
+++ b/app/src/databricks_labs_dqx_app/backend/rule_enums.py
@@ -1,4 +1,4 @@
-"""Lifecycle enums for the per-table rules catalog (``dq_quality_rules``).
+"""Lifecycle enums for the per-table rules catalog (``dq_resolved_rules``).
 
 Kept in a leaf module so migrations and ``RulesCatalogService`` can import them
 without pulling in ``models`` (which itself imports services that import the

--- a/app/src/databricks_labs_dqx_app/backend/services/apply_rules_service.py
+++ b/app/src/databricks_labs_dqx_app/backend/services/apply_rules_service.py
@@ -125,7 +125,7 @@ class ApplyRulesService:
         self._app_settings = app_settings
         self._table = sql.fqn("dq_applied_rules")
         self._monitored_table = sql.fqn("dq_monitored_tables")
-        self._quality_rules_table = sql.fqn("dq_quality_rules")
+        self._quality_rules_table = sql.fqn("dq_resolved_rules")
         self._suppressions_table = sql.fqn("dq_tag_auto_suppressions")
         self._select_cols = self._build_select_cols()
 
@@ -600,7 +600,7 @@ class ApplyRulesService:
           identical-mapping-hash update-in-place case.
         - A mapping change (new ``mapping_hash``) inserts the new row via
           :meth:`apply_rule` and removes the old row (via :meth:`remove_applied`,
-          which also cleans up any materialized ``dq_quality_rules`` rows)
+          which also cleans up any materialized ``dq_resolved_rules`` rows)
           since it no longer matches any desired entry's hash.
         - Any existing row whose ``rule_id`` isn't in *desired* at all is
           removed the same way.
@@ -758,7 +758,7 @@ class ApplyRulesService:
     # ------------------------------------------------------------------
 
     def remove_applied(self, applied_rule_id: str, user_email: str | None = None) -> None:
-        """Remove an applied rule and every ``dq_quality_rules`` row it materialized.
+        """Remove an applied rule and every ``dq_resolved_rules`` row it materialized.
 
         Suppression tombstone: when the removed row was TAG-AUTO applied
         (``user_metadata[ORIGIN_KEY] == ORIGIN_TAG_AUTO``), this also records a

--- a/app/src/databricks_labs_dqx_app/backend/services/data_product_service.py
+++ b/app/src/databricks_labs_dqx_app/backend/services/data_product_service.py
@@ -983,7 +983,7 @@ class DataProductService:
         (:meth:`_live_check_counts`): a rule expands to one check per mapping
         group (e.g. per column for a for-each-column rule), so a saved space
         shows the real non-zero count instead of ``summary.check_count`` — which
-        counts ``dq_quality_rules`` rows that only exist after
+        counts ``dq_resolved_rules`` rows that only exist after
         approval/materialization and is therefore ``0`` for a freshly-saved
         draft (P-item 44).
 
@@ -1028,7 +1028,7 @@ class DataProductService:
         ``# Checks`` must be the number of DQ checks a member's applied rules
         actually produce — one per mapping group, so a for-each-column rule
         expands to several checks. ``MonitoredTableSummary.check_count`` counts
-        materialized ``dq_quality_rules`` rows, which only exist after
+        materialized ``dq_resolved_rules`` rows, which only exist after
         approval/run, so a freshly-saved DRAFT space reported ``0`` (P-item 44).
 
         Mirrors the monitored-tables overview's

--- a/app/src/databricks_labs_dqx_app/backend/services/materializer.py
+++ b/app/src/databricks_labs_dqx_app/backend/services/materializer.py
@@ -1,8 +1,8 @@
-"""Materializer (Phase 3C) — renders applied registry rules into ``dq_quality_rules``.
+"""Materializer (Phase 3C) — renders applied registry rules into ``dq_resolved_rules``.
 
 This is the SAFETY-CRITICAL boundary between the Rules Registry (authoring/
 governance layer) and the existing, UNCHANGED runner: every
-``dq_quality_rules`` row this module writes must be shaped exactly like a
+``dq_resolved_rules`` row this module writes must be shaped exactly like a
 row a human would have hand-authored through the single-table editor
 (``RulesCatalogService``), because the wheel-task runner that executes
 checks was not touched by the Rules Registry work and only understands
@@ -22,11 +22,11 @@ override). A binding's applied rules only get (re-)materialized when:
   -> :meth:`Materializer.rematerialize_for_rule`).
 
 Applying, pinning, or overriding a rule only ever writes to
-``dq_applied_rules``; it never touches ``dq_quality_rules`` until one of
+``dq_applied_rules``; it never touches ``dq_resolved_rules`` until one of
 the two publish-triggered calls above runs.
 
 For each ``dq_applied_rules`` row under a monitored table binding, this
-renders ONE ``dq_quality_rules`` row per mapping GROUP in
+renders ONE ``dq_resolved_rules`` row per mapping GROUP in
 ``column_mapping`` (slots substituted with real columns, non-``None``
 parameter values filled in), stamps dimension/severity/polarity/
 provenance into ``user_metadata`` (§9 — the runner already aggregates
@@ -60,6 +60,7 @@ from collections.abc import Mapping
 from typing import Any
 
 from databricks.labs.dqx.errors import UnsafeSqlQueryError
+from databricks.labs.dqx.rule import compute_rule_fingerprint
 from databricks.labs.dqx.utils import is_sql_query_safe
 
 from databricks_labs_dqx_app.backend.registry_models import (
@@ -287,7 +288,7 @@ def render_check(
     row_filter: str | None = None,
     pass_threshold: int | None = None,
 ) -> tuple[dict[str, Any], bool]:
-    """Render one materialized ``dq_quality_rules.check`` dict for one mapping group.
+    """Render one materialized ``dq_resolved_rules.check`` dict for one mapping group.
 
     *app_settings* is only read to resolve the rendered ``criticality``: the
     severity -> criticality mapping is admin-editable via the reserved
@@ -488,12 +489,12 @@ def _slugify(value: str) -> str:
 
 
 class Materializer:
-    """Renders applied registry rules into ``dq_quality_rules`` rows (Phase 3C).
+    """Renders applied registry rules into ``dq_resolved_rules`` rows (Phase 3C).
 
     Reads live application state (``dq_applied_rules`` via
     :class:`MonitoredTableService`) and the registry's frozen publish
     snapshots (``dq_rule_versions`` via :class:`RegistryService`), and
-    writes/upserts/cleans-up ``dq_quality_rules`` rows accordingly.
+    writes/upserts/cleans-up ``dq_resolved_rules`` rows accordingly.
     """
 
     def __init__(
@@ -507,13 +508,13 @@ class Materializer:
         self._registry = registry
         self._monitored_tables = monitored_tables
         self._app_settings = app_settings
-        self._quality_rules_table = sql.fqn("dq_quality_rules")
+        self._quality_rules_table = sql.fqn("dq_resolved_rules")
         self._check_col = sql.q("check")
 
     def materialize_binding(self, binding_id: str) -> list[str]:
         """Materialize every applied rule under *binding_id*.
 
-        Returns the sorted list of materialized ``dq_quality_rules.rule_id``
+        Returns the sorted list of materialized ``dq_resolved_rules.rule_id``
         values written (for diagnostics/tests).
 
         Raises:
@@ -682,7 +683,7 @@ class Materializer:
         # exposes the slots this follower's stored column_mapping binds), an
         # empty result must NOT be treated as delete-all: doing so would
         # ``_delete_stale_groups(expected=∅)`` and wipe every approved
-        # ``dq_quality_rules`` row for this application, then the downstream
+        # ``dq_resolved_rules`` row for this application, then the downstream
         # re-freeze would empty the frozen snapshot and leave the binding
         # unrunnable. Instead leave the existing rows untouched (mirroring the
         # ``rendered is None`` early-return) so the previous approved checks
@@ -743,15 +744,19 @@ class Materializer:
         existing = self._get_materialized_row(row_id)
         check_json = json.dumps(check, sort_keys=True)
         check_expr = self._sql.json_literal_expr(json.dumps(check))
+        # dqx-core per-rule fingerprint, stored so the dq_rules_core view can
+        # expose it (same contract as RulesCatalogService's authored rows).
+        e_fp = escape_sql_string(compute_rule_fingerprint(check))
 
         if existing is None:
             self._sql.execute(
                 f"INSERT INTO {self._quality_rules_table} "
                 f"(rule_id, table_fqn, {self._check_col}, version, status, source, "
-                "registry_rule_id, registry_version, applied_rule_id, created_by, created_at, updated_by, updated_at) "
+                "registry_rule_id, registry_version, applied_rule_id, rule_fingerprint, "
+                "created_by, created_at, updated_by, updated_at) "
                 f"VALUES ('{escape_sql_string(row_id)}', '{escape_sql_string(table_fqn)}', {check_expr}, "
                 f"{version_number}, 'draft', 'registry', '{escape_sql_string(applied.rule_id)}', "
-                f"{version_number}, '{escape_sql_string(applied.id or '')}', "
+                f"{version_number}, '{escape_sql_string(applied.id or '')}', '{e_fp}', "
                 f"{self._opt_str(applied.created_by)}, now(), {self._opt_str(applied.created_by)}, now())"
             )
             return
@@ -776,6 +781,7 @@ class Materializer:
             f"  registry_rule_id = '{escape_sql_string(applied.rule_id)}', "
             f"  registry_version = {version_number}, "
             f"  applied_rule_id = '{escape_sql_string(applied.id or '')}', "
+            f"  rule_fingerprint = '{e_fp}', "
             "  updated_at = now() "
             f"WHERE rule_id = '{escape_sql_string(row_id)}'"
         )
@@ -830,7 +836,7 @@ class Materializer:
         return status, registry_version, normalized
 
     def _existing_group_ids(self, applied_rule_id: str | None) -> set[str]:
-        """Return the ``dq_quality_rules.rule_id``s currently materialized for *applied_rule_id*.
+        """Return the ``dq_resolved_rules.rule_id``s currently materialized for *applied_rule_id*.
 
         Used by :meth:`_materialize_applied_rule` to preserve (and keep
         counting as "expected") the rows of an application whose every mapping
@@ -884,7 +890,7 @@ class Materializer:
         Read-only draft-run source (design spec §4.1, ``source == draft``):
         renders every applied rule under *binding_id* through the SAME
         :meth:`_iter_rendered_checks` path materialization uses, but writes
-        NOTHING to ``dq_quality_rules``. The returned list is exactly the
+        NOTHING to ``dq_resolved_rules``. The returned list is exactly the
         shape the runner consumes (same as
         ``RulesCatalogService.get_approved_checks_for_table`` output), so a
         draft run of a monitored table executes its live authored state

--- a/app/src/databricks_labs_dqx_app/backend/services/monitored_table_service.py
+++ b/app/src/databricks_labs_dqx_app/backend/services/monitored_table_service.py
@@ -7,7 +7,7 @@ Manages the LIVE ``dq_monitored_tables`` bindings and their
 This is Layer 2 of the Rules Registry: a thin binding recording that a
 table is under active governance, plus the live link between a published
 registry rule (``dq_rules``) and that table's column mapping. Applying new
-rules, mapping columns, and materializing into ``dq_quality_rules`` (Phase
+rules, mapping columns, and materializing into ``dq_resolved_rules`` (Phase
 3C) are explicitly out of scope here — this module only covers register/
 list/get/delete of the binding + applied rules, and a READ-ONLY path over
 the existing ``dq_profiling_results`` Delta table (never written here; the
@@ -203,7 +203,7 @@ class MonitoredTableService:
         self._versions_table = sql.fqn("dq_monitored_table_versions")
         self._applied_table = sql.fqn("dq_applied_rules")
         self._rules_table = sql.fqn("dq_rules")
-        self._quality_rules_table = sql.fqn("dq_quality_rules")
+        self._quality_rules_table = sql.fqn("dq_resolved_rules")
         self._score_cache_table = sql.fqn("dq_score_cache")
         self._profiling_table = profiling_sql.fqn("dq_profiling_results")
         # ``dq_validation_runs`` is always Delta (written by the runner job),
@@ -560,12 +560,12 @@ class MonitoredTableService:
         return out
 
     def _materialized_check_counts(self, table_fqns: list[str]) -> dict[str, int]:
-        """Count active ``dq_quality_rules`` rows per *table_fqns* entry, regardless of authoring source.
+        """Count active ``dq_resolved_rules`` rows per *table_fqns* entry, regardless of authoring source.
 
         One grouped query for all listed tables (no per-table round-trip); a
         table with zero active rows is simply absent from the result.
 
-        ``dq_quality_rules`` holds every check for a table — authored
+        ``dq_resolved_rules`` holds every check for a table — authored
         directly (``source`` in ``ui``/``sql``/``profiler``/``import``/``ai``)
         as well as materialized from a Rules Registry application
         (``source = 'registry'``). This must count all of them, not just
@@ -887,7 +887,7 @@ class MonitoredTableService:
         """Set a monitored table binding's own review-lifecycle status flag.
 
         Only flips the binding row's ``status`` column — it never touches
-        ``dq_applied_rules`` or the materialized ``dq_quality_rules`` rows.
+        ``dq_applied_rules`` or the materialized ``dq_resolved_rules`` rows.
         The route layer (``routes/v1/monitored_tables.py``) orchestrates the
         binding status alongside the materializer and the per-rule
         submit/approve/reject transitions so the binding's status stays a
@@ -1034,10 +1034,10 @@ class MonitoredTableService:
         return table
 
     def list_materialized_rule_statuses(self, binding_id: str) -> list[tuple[str, str]]:
-        """Return ``(rule_id, status)`` for every ``dq_quality_rules`` row this binding materialized.
+        """Return ``(rule_id, status)`` for every ``dq_resolved_rules`` row this binding materialized.
 
         Resolves the binding's materialized rows through the SAME
-        ``dq_quality_rules.applied_rule_id`` -> ``dq_applied_rules.id`` ->
+        ``dq_resolved_rules.applied_rule_id`` -> ``dq_applied_rules.id`` ->
         ``dq_applied_rules.binding_id`` linkage the materializer maintains
         (:meth:`Materializer.materialize_binding` /
         :meth:`Materializer._cleanup_orphans`), rather than matching on
@@ -1111,7 +1111,7 @@ class MonitoredTableService:
         """Delete a monitored table binding and its applied rules.
 
         TODO(Phase 3C): once the materializer exists, de-materialize (or at
-        minimum orphan-flag) any ``dq_quality_rules`` rows whose
+        minimum orphan-flag) any ``dq_resolved_rules`` rows whose
         ``applied_rule_id`` references an application under this binding
         before deleting the rows here — otherwise materialized runner rows
         are left pointing at applications that no longer exist. Not

--- a/app/src/databricks_labs_dqx_app/backend/services/monitored_table_versions.py
+++ b/app/src/databricks_labs_dqx_app/backend/services/monitored_table_versions.py
@@ -36,7 +36,7 @@ place and stamps ``refrozen_at`` (:meth:`refreeze_current`) —
 auto-upgrade, a per-rule approval, or a per-rule rejection/deprecation.
 
 Scoping (SAFETY-CRITICAL): a binding's approved rows are identified via
-the ``dq_quality_rules.applied_rule_id`` -> ``dq_applied_rules.id`` ->
+the ``dq_resolved_rules.applied_rule_id`` -> ``dq_applied_rules.id`` ->
 ``dq_applied_rules.binding_id`` linkage the materializer maintains — NEVER
 by ``table_fqn`` alone (the P16-H pattern in
 ``routes/v1/monitored_tables.py``). Directly-authored (non-registry)
@@ -67,7 +67,7 @@ logger = logging.getLogger(__name__)
 class MonitoredTableVersionService:
     """Freezes/reads per-version approved-rule REFERENCE snapshots for monitored tables.
 
-    Reads the binding's current approved ``dq_quality_rules`` rows (through
+    Reads the binding's current approved ``dq_resolved_rules`` rows (through
     :class:`RulesCatalogService` + the applied-rule linkage on
     :class:`MonitoredTableService`) to determine which applied rules — and at
     which resolved registry version — belong to the approved set, and
@@ -90,7 +90,7 @@ class MonitoredTableVersionService:
         self._versions_table = sql.fqn("dq_monitored_table_versions")
         self._tables = sql.fqn("dq_monitored_tables")
         self._applied_table = sql.fqn("dq_applied_rules")
-        self._quality_rules_table = sql.fqn("dq_quality_rules")
+        self._quality_rules_table = sql.fqn("dq_resolved_rules")
 
     # ------------------------------------------------------------------
     # Freeze / re-freeze
@@ -99,7 +99,7 @@ class MonitoredTableVersionService:
     def freeze_new_version(self, binding_id: str, user_email: str) -> int:
         """Bump the binding's version and freeze the current approved rule set as vN.
 
-        Reads the binding's CURRENT approved ``dq_quality_rules`` rows
+        Reads the binding's CURRENT approved ``dq_resolved_rules`` rows
         (scoped to this binding's ``applied_rule_id``s), increments
         ``dq_monitored_tables.version``, and inserts a new
         ``dq_monitored_table_versions`` snapshot at the new version.
@@ -202,7 +202,7 @@ class MonitoredTableVersionService:
         )
 
     def refreeze_for_quality_rule(self, rule_id: str) -> str | None:
-        """Re-freeze the binding owning materialized ``dq_quality_rules`` *rule_id*.
+        """Re-freeze the binding owning materialized ``dq_resolved_rules`` *rule_id*.
 
         Hook entry point for per-rule approve/reject in
         ``routes/v1/rules.py``: resolves the row's ``applied_rule_id`` ->
@@ -400,7 +400,7 @@ class MonitoredTableVersionService:
         Determines which applied rules belong to the binding's approved set
         (scoped by ``applied_rule_id``, excluding directly-authored rules) and
         the RESOLVED registry version each was rendered at, by reading the
-        approved ``dq_quality_rules`` rows via
+        approved ``dq_resolved_rules`` rows via
         ``RulesCatalogService.get_approved_checks_for_table``. Returns
         ``state_json`` carrying, per approved applied rule, the reference the
         runner payload is reconstructed from (``rule_refs``), the display
@@ -410,7 +410,7 @@ class MonitoredTableVersionService:
         all_checks = self._rules_catalog.get_approved_checks_for_table(detail.table.table_fqn)
         # Resolved registry version per approved applied rule, plus how many
         # rendered checks it contributes — read straight off the frozen
-        # ``dq_quality_rules`` checks (their ``user_metadata`` carries both).
+        # ``dq_resolved_rules`` checks (their ``user_metadata`` carries both).
         resolved_version: dict[str, int] = {}
         check_count = 0
         for check in all_checks:

--- a/app/src/databricks_labs_dqx_app/backend/services/registry_service.py
+++ b/app/src/databricks_labs_dqx_app/backend/services/registry_service.py
@@ -13,7 +13,7 @@ by ``ApplyRulesService``).
 Mirrors :class:`~databricks_labs_dqx_app.backend.services.rules_catalog_service.RulesCatalogService`'s
 shape (status machine, history recording, dialect-portable SQL via the
 executor helpers) but operates on the registry tables instead of
-per-table ``dq_quality_rules``.
+per-table ``dq_resolved_rules``.
 """
 
 import json

--- a/app/src/databricks_labs_dqx_app/backend/services/rules_catalog_service.py
+++ b/app/src/databricks_labs_dqx_app/backend/services/rules_catalog_service.py
@@ -4,6 +4,8 @@ from datetime import datetime, timezone
 from typing import Any
 from uuid import uuid4
 
+from databricks.labs.dqx.rule import compute_rule_fingerprint
+
 from databricks_labs_dqx_app.backend.rule_enums import RuleSource, RuleStatus
 from databricks_labs_dqx_app.backend.sql_executor import OltpExecutorProtocol
 from databricks_labs_dqx_app.backend.sql_utils import escape_sql_string
@@ -66,8 +68,8 @@ class RulesCatalogService:
 
     def __init__(self, sql: OltpExecutorProtocol) -> None:
         self._sql = sql
-        self._table = sql.fqn("dq_quality_rules")
-        self._history_table = sql.fqn("dq_quality_rules_history")
+        self._table = sql.fqn("dq_resolved_rules")
+        self._history_table = sql.fqn("dq_resolved_rules_history")
         # ``check`` is a SQL reserved word in both Delta and Postgres,
         # so quote it via the executor so we get backticks on Delta and
         # double-quotes on Postgres.
@@ -170,12 +172,16 @@ class RulesCatalogService:
             rule_id = uuid4().hex[:16]
             check_json = json.dumps(check)
             check_expr = self._sql.json_literal_expr(check_json)
+            # dqx-core per-rule fingerprint (SHA-256 of the canonicalized check),
+            # stored so the dq_rules_core view can expose it and external
+            # pipelines can load these rules via DQEngine.load_checks.
+            e_fp = escape_sql_string(compute_rule_fingerprint(check))
             sql = (
                 f"INSERT INTO {self._table} "
                 f"(rule_id, table_fqn, {check_col}, version, status, source, "
-                f"created_by, created_at, updated_by, updated_at) "
+                f"rule_fingerprint, created_by, created_at, updated_by, updated_at) "
                 f"VALUES ('{rule_id}', '{e_table}', {check_expr}, 1, 'draft', '{e_source}', "
-                f"'{e_user}', now(), '{e_user}', now())"
+                f"'{e_fp}', '{e_user}', now(), '{e_user}', now())"
             )
             self._sql.execute(sql)
             self._record_history(
@@ -229,12 +235,16 @@ class RulesCatalogService:
         check_expr = self._sql.json_literal_expr(check_json)
         e_user = escape_sql_string(user_email)
         e_rule_id = escape_sql_string(rule_id)
+        # Recompute the per-rule fingerprint from the new check content so the
+        # stored value stays in lock-step with the rule (see save()).
+        e_fp = escape_sql_string(compute_rule_fingerprint(check))
 
         sql = (
             f"UPDATE {self._table} SET "
             f"  {self._check_col} = {check_expr}, "
             f"  version = version + 1, "
             f"  status = 'draft', "
+            f"  rule_fingerprint = '{e_fp}', "
             f"  updated_by = '{e_user}', "
             f"  updated_at = now() "
             f"WHERE rule_id = '{e_rule_id}'"
@@ -612,7 +622,7 @@ class RulesCatalogService:
     def get_history(self, rule_id: str, limit: int = 50) -> list[dict[str, Any]]:
         """Return a rule's recorded change history (newest first).
 
-        Reads the append-only ``dq_quality_rules_history`` audit trail written
+        Reads the append-only ``dq_resolved_rules_history`` audit trail written
         by :meth:`_record_history`. Each entry carries the post-state ``check``
         payload and the ``prev_status``/``new_status`` transition, so callers
         (Drafts & Review's change-diff popout) can reconstruct a
@@ -649,7 +659,7 @@ class RulesCatalogService:
 
     @staticmethod
     def _history_row_to_dict(row: list[str]) -> dict[str, Any]:
-        """Map a raw ``dq_quality_rules_history`` row to a serializable dict."""
+        """Map a raw ``dq_resolved_rules_history`` row to a serializable dict."""
         check_raw = row[2]
         check: dict[str, Any] | None = None
         if check_raw:

--- a/app/src/databricks_labs_dqx_app/backend/services/schedule_config_service.py
+++ b/app/src/databricks_labs_dqx_app/backend/services/schedule_config_service.py
@@ -47,7 +47,7 @@ class ScheduleConfigService:
         self._sql = sql
         self._table = sql.fqn("dq_schedule_configs")
         self._history_table = sql.fqn("dq_schedule_configs_history")
-        self._rules_table = sql.fqn("dq_quality_rules")
+        self._rules_table = sql.fqn("dq_resolved_rules")
 
     def resolve_scope_table_fqns(self, config: dict[str, Any]) -> list[str]:
         """Resolve the real table FQNs a scope-config schedule would run against.

--- a/app/src/databricks_labs_dqx_app/backend/services/scheduler_service.py
+++ b/app/src/databricks_labs_dqx_app/backend/services/scheduler_service.py
@@ -224,7 +224,7 @@ _DELTA_RETENTION_TABLES: tuple[tuple[str, str], ...] = (
     ("dq_metrics", "run_time"),
 )
 _OLTP_RETENTION_TABLES: tuple[tuple[str, str], ...] = (
-    ("dq_quality_rules_history", "changed_at"),
+    ("dq_resolved_rules_history", "changed_at"),
     ("dq_schedule_configs_history", "changed_at"),
 )
 
@@ -348,7 +348,7 @@ class SchedulerService:
         self._table = self._oltp_sql.fqn("dq_schedule_runs")
         self._configs_table = self._oltp_sql.fqn("dq_schedule_configs")
         self._settings_table = self._oltp_sql.fqn("dq_app_settings")
-        self._rules_table = self._oltp_sql.fqn("dq_quality_rules")
+        self._rules_table = self._oltp_sql.fqn("dq_resolved_rules")
         self._products_table = self._oltp_sql.fqn("dq_data_products")
         self._monitored_tables_table = self._oltp_sql.fqn("dq_monitored_tables")
         self._data_product_service = data_product_service

--- a/app/src/databricks_labs_dqx_app/ui/components/monitored-tables/MonitoredTablesTable.tsx
+++ b/app/src/databricks_labs_dqx_app/ui/components/monitored-tables/MonitoredTablesTable.tsx
@@ -224,7 +224,7 @@ const COLUMNS: Record<MonitoredTablesSortKey, ColumnDef> = {
     renderCell: () => <span className="text-muted-foreground">—</span>,
   },
   checksCount: {
-    // Count of materialized checks (`dq_quality_rules` rows sourced from the
+    // Count of materialized checks (`dq_resolved_rules` rows sourced from the
     // Rules Registry) for the table — distinct from `rulesCount` (applied
     // registry rules), matching dqlake's `BindingOutBrief.check_count`.
     labelKey: "monitoredTables.colChecksCount",

--- a/app/src/databricks_labs_dqx_app/ui/components/registry-rules/RegistryRuleJsonDialog.tsx
+++ b/app/src/databricks_labs_dqx_app/ui/components/registry-rules/RegistryRuleJsonDialog.tsx
@@ -42,7 +42,7 @@ interface RegistryRuleJsonDialogProps {
  * View the rule's native DQX-compatible check JSON — the exact
  * `{ criticality, check: { function, arguments }, user_metadata, name?,
  * message_expr? }` dict shape `materializer.render_check` stamps into the
- * materialized `dq_quality_rules.check` row, derived from the rule's stored
+ * materialized `dq_resolved_rules.check` row, derived from the rule's stored
  * `definition` and `user_metadata` (see `lib/registry-rule-conversion.ts`;
  * no separate stored copy — the `definition` already IS the persisted
  * structured form, per the Rules Registry design). `user_metadata` is

--- a/app/src/databricks_labs_dqx_app/ui/lib/api.ts
+++ b/app/src/databricks_labs_dqx_app/ui/lib/api.ts
@@ -2436,7 +2436,7 @@ export type MonitoredTableReviewOutNewVersion = number | null;
  * Response for the submit/approve/reject monitored-table lifecycle routes.
 
 ``table`` carries the binding with its new roll-up status; ``affected_check_count``
-is how many materialized ``dq_quality_rules`` rows changed status in this
+is how many materialized ``dq_resolved_rules`` rows changed status in this
 transition (submitted, approved, or rejected respectively).
  */
 export interface MonitoredTableReviewOut {
@@ -3371,12 +3371,12 @@ export interface RuleCatalogEntryOut {
 export type RuleDefinitionBody = { [key: string]: unknown };
 
 /**
- * Optional custom failure message (a Spark SQL expression string), mirroring DQRule.message_expr. Threaded through create/update and frozen into each dq_rule_versions snapshot as part of the definition. Materialized as a top-level 'message_expr' key on the rendered dq_quality_rules check when set; omitted entirely when None or empty.
+ * Optional custom failure message (a Spark SQL expression string), mirroring DQRule.message_expr. Threaded through create/update and frozen into each dq_rule_versions snapshot as part of the definition. Materialized as a top-level 'message_expr' key on the rendered dq_resolved_rules check when set; omitted entirely when None or empty.
  */
 export type RuleDefinitionErrorMessage = string | null;
 
 /**
- * Optional rule-level row filter (a SQL WHERE predicate), mirroring DQRule.filter. Supports {{slot}} placeholders substituted at materialize time. Validated for SQL safety on create/update. Threaded through create/update and frozen into each dq_rule_versions snapshot as part of the definition. Materialized as a top-level 'filter' key on the rendered dq_quality_rules check when set; omitted entirely when None or empty.
+ * Optional rule-level row filter (a SQL WHERE predicate), mirroring DQRule.filter. Supports {{slot}} placeholders substituted at materialize time. Validated for SQL safety on create/update. Threaded through create/update and frozen into each dq_rule_versions snapshot as part of the definition. Materialized as a top-level 'filter' key on the rendered dq_resolved_rules check when set; omitted entirely when None or empty.
  */
 export type RuleDefinitionFilter = string | null;
 
@@ -3395,9 +3395,9 @@ export interface RuleDefinition {
   body?: RuleDefinitionBody;
   slots?: RuleSlot[];
   parameters?: RuleParameter[];
-  /** Optional custom failure message (a Spark SQL expression string), mirroring DQRule.message_expr. Threaded through create/update and frozen into each dq_rule_versions snapshot as part of the definition. Materialized as a top-level 'message_expr' key on the rendered dq_quality_rules check when set; omitted entirely when None or empty. */
+  /** Optional custom failure message (a Spark SQL expression string), mirroring DQRule.message_expr. Threaded through create/update and frozen into each dq_rule_versions snapshot as part of the definition. Materialized as a top-level 'message_expr' key on the rendered dq_resolved_rules check when set; omitted entirely when None or empty. */
   error_message?: RuleDefinitionErrorMessage;
-  /** Optional rule-level row filter (a SQL WHERE predicate), mirroring DQRule.filter. Supports {{slot}} placeholders substituted at materialize time. Validated for SQL safety on create/update. Threaded through create/update and frozen into each dq_rule_versions snapshot as part of the definition. Materialized as a top-level 'filter' key on the rendered dq_quality_rules check when set; omitted entirely when None or empty. */
+  /** Optional rule-level row filter (a SQL WHERE predicate), mirroring DQRule.filter. Supports {{slot}} placeholders substituted at materialize time. Validated for SQL safety on create/update. Threaded through create/update and frozen into each dq_rule_versions snapshot as part of the definition. Materialized as a top-level 'filter' key on the rendered dq_resolved_rules check when set; omitted entirely when None or empty. */
   filter?: RuleDefinitionFilter;
 }
 
@@ -3428,7 +3428,7 @@ export type RuleHistoryEntryOutChangedAt = string | null;
 export type RuleHistoryEntryOutRationale = string | null;
 
 /**
- * One recorded change from the ``dq_quality_rules_history`` audit log.
+ * One recorded change from the ``dq_resolved_rules_history`` audit log.
 
 Backs ``getRuleHistory`` — the per-rule change trail that lets Drafts &
 Review show a previous-vs-proposed diff for a per-table rule draft. Each
@@ -13186,7 +13186,7 @@ export const useSaveRules = <TError = AxiosError<HTTPValidationError>,
  * Return a per-table rule's recorded change history (newest first).
 
 Backs the Drafts & Review change-diff popout: reads the
-``dq_quality_rules_history`` audit trail so the UI can diff the two most
+``dq_resolved_rules_history`` audit trail so the UI can diff the two most
 recent recorded ``check`` payloads (previous vs proposed). Declared BEFORE
 the ``/{table_fqn:path}`` catch-all so the more-specific pattern wins.
 
@@ -14836,14 +14836,14 @@ and swallows call failures internally, so in practice this can never
 turn a successful publish into a 500.
 
 Also re-materializes every FOLLOWING (unpinned) application of this
-rule (design spec §5) so their ``dq_quality_rules`` copies pick up the
+rule (design spec §5) so their ``dq_resolved_rules`` copies pick up the
 new version — see ``Materializer.rematerialize_for_rule``. PINNED
 applications are untouched by a publish; they only change via a
 direct edit.
 
 Data Products Task 2 re-freeze hook (design spec §3.2 (a)): when
 ``auto_upgrade_without_approval`` is ON, a follower's approved
-``dq_quality_rules`` row silently picks up the new content and STAYS
+``dq_resolved_rules`` row silently picks up the new content and STAYS
 approved, changing the binding's approved rule set without a table
 re-approval — so each re-materialized binding's current version snapshot
 is re-frozen in place. When auto-upgrade is OFF the changed rows drop to
@@ -15604,7 +15604,7 @@ Requires ``MODIFY`` on the monitored table (direct/inherited/owner) unless
 the caller is an admin/approver.
 
 TODO(Phase 3C): once the materializer exists, block/handle
-de-materialization of any ``dq_quality_rules`` rows tied to this
+de-materialization of any ``dq_resolved_rules`` rows tied to this
 binding's applications before allowing deletion.
  * @summary Delete Monitored Table
  */
@@ -16790,7 +16790,7 @@ export function useListPendingApplicationsSuspense<TData = Awaited<ReturnType<ty
 
 
 /**
- * Remove an applied rule and every ``dq_quality_rules`` row it materialized.
+ * Remove an applied rule and every ``dq_resolved_rules`` row it materialized.
 
 Requires ``APPLY`` on the monitored table unless the caller is an admin/approver.
  * @summary Remove Applied Rule
@@ -16991,7 +16991,7 @@ export const useSetAppliedRuleSeverityOverride = <TError = AxiosError<HTTPValida
 /**
  * Submit a monitored table for review.
 
-Materializes the binding's applied rules into ``dq_quality_rules`` (the
+Materializes the binding's applied rules into ``dq_resolved_rules`` (the
 UI has already persisted any staged edits via ``saveAppliedRules``), then
 submits every freshly-materialized ``draft`` check for approval — reusing
 the same per-rule transition the Drafts & Review queue uses — and rolls
@@ -17075,7 +17075,7 @@ export const useSubmitMonitoredTable = <TError = AxiosError<HTTPValidationError>
 Reuses the per-rule approve transition so each check's audit trail is
 identical to a hand-approval, then rolls the binding up to ``approved``.
 From here the scheduler picks the checks up (it runs only ``approved``
-``dq_quality_rules`` rows).
+``dq_resolved_rules`` rows).
 
 Table approval is the ONLY event that bumps the monitored-table version:
 after the binding rolls up to ``approved`` the newly-approved rule set is

--- a/app/src/databricks_labs_dqx_app/ui/lib/registry-rule-conversion.ts
+++ b/app/src/databricks_labs_dqx_app/ui/lib/registry-rule-conversion.ts
@@ -12,7 +12,7 @@
  *   Also includes `user_metadata` — the rule's reserved tags
  *   (name/description/dimension/severity) plus any free-text tags — since
  *   that dict IS what `render_check` stamps into the materialized
- *   `dq_quality_rules.check` row (minus the per-application provenance keys
+ *   `dq_resolved_rules.check` row (minus the per-application provenance keys
  *   — `registry_rule_id`, `registry_version`, `applied_rule_id`,
  *   `polarity` — that only exist once a rule is applied to a table and
  *   therefore have no meaning on a still-unattached registry rule).
@@ -473,7 +473,7 @@ export interface MaterializableRule {
  * substitution, since a registry rule is table-agnostic). Includes
  * `user_metadata` — *rule*'s own tags dict, unchanged — so the JSON shown
  * to the user faithfully mirrors what flows into the materialized
- * `dq_quality_rules.check` row (see the module docstring for exactly which
+ * `dq_resolved_rules.check` row (see the module docstring for exactly which
  * per-application keys are intentionally excluded).
  *
  * Pass *severityCriticality* (see {@link severityValueCriticality}) so the

--- a/app/src/databricks_labs_dqx_app/ui/routes/_sidebar/route.tsx
+++ b/app/src/databricks_labs_dqx_app/ui/routes/_sidebar/route.tsx
@@ -82,7 +82,7 @@ function Layout() {
 
             {/* Monitored Tables — apply registry rules to real tables
                 (slot->column mapping), profile them, and publish to
-                materialize into dq_quality_rules (Phase 3D). */}
+                materialize into dq_resolved_rules (Phase 3D). */}
             <SidebarMenuItem>
               <SidebarMenuButton
                 asChild

--- a/app/tests/integration/test_setup_resources.py
+++ b/app/tests/integration/test_setup_resources.py
@@ -19,8 +19,8 @@ from databricks_labs_dqx_app.backend.startup import publish_wheels_to_volume
 _EXPECTED_OLTP_TABLES = (
     "dq_migrations",
     "dq_app_settings",
-    "dq_quality_rules",
-    "dq_quality_rules_history",
+    "dq_resolved_rules",
+    "dq_resolved_rules_history",
     "dq_role_mappings",
     "dq_comments",
     "dq_schedule_runs",

--- a/app/tests/test_apply_rules_service.py
+++ b/app/tests/test_apply_rules_service.py
@@ -461,7 +461,7 @@ class TestSaveAppliedRules:
         assert len(results) == 1
         assert results[0].column_mapping == new_mapping
         calls = [c.args[0] for c in sql.execute.call_args_list]
-        assert any("DELETE FROM dqx_test.dqx_app_test.dq_quality_rules" in c for c in calls)
+        assert any("DELETE FROM dqx_test.dqx_app_test.dq_resolved_rules" in c for c in calls)
         assert any("DELETE FROM dqx_test.dqx_app_test.dq_applied_rules" in c for c in calls)
         assert any("INSERT INTO dqx_test.dqx_app_test.dq_applied_rules" in c for c in calls)
 
@@ -476,7 +476,7 @@ class TestSaveAppliedRules:
         assert results == []
         registry.get_rule.assert_not_called()
         calls = [c.args[0] for c in sql.execute.call_args_list]
-        assert any("DELETE FROM dqx_test.dqx_app_test.dq_quality_rules" in c for c in calls)
+        assert any("DELETE FROM dqx_test.dqx_app_test.dq_resolved_rules" in c for c in calls)
         assert any("DELETE FROM dqx_test.dqx_app_test.dq_applied_rules" in c for c in calls)
         assert not any("INSERT INTO" in c for c in calls)
 
@@ -635,7 +635,7 @@ class TestRemoveApplied:
         sql.query.return_value = [_applied_row(id_="ar1")]
         svc.remove_applied("ar1")
         calls = [c.args[0] for c in sql.execute.call_args_list]
-        assert any("DELETE FROM dqx_test.dqx_app_test.dq_quality_rules" in c and "applied_rule_id" in c for c in calls)
+        assert any("DELETE FROM dqx_test.dqx_app_test.dq_resolved_rules" in c and "applied_rule_id" in c for c in calls)
         assert any("DELETE FROM dqx_test.dqx_app_test.dq_applied_rules" in c for c in calls)
 
     def test_raises_when_missing(self, svc, sql):

--- a/app/tests/test_data_products.py
+++ b/app/tests/test_data_products.py
@@ -491,7 +491,7 @@ class TestListAndGet:
         self, service, sql, monitored_tables, materializer
     ):
         """P-item 44: a freshly-saved DRAFT space's ``# Checks`` must reflect the
-        checks its applied rules expand to, NOT the materialized ``dq_quality_rules``
+        checks its applied rules expand to, NOT the materialized ``dq_resolved_rules``
         row count (0 until approval/run). ``# Rules`` stays the applied-rule count."""
         sql.query.side_effect = [
             [_product_row(product_id="p1", status="draft", version="0")],

--- a/app/tests/test_materializer.py
+++ b/app/tests/test_materializer.py
@@ -3,7 +3,7 @@ between the Rules Registry and the unchanged runner.
 
 Two layers are exercised:
 
-* ``render_check`` (pure function) — the exact ``dq_quality_rules.check``
+* ``render_check`` (pure function) — the exact ``dq_resolved_rules.check``
   shape produced for one applied-rule mapping group. The **critical test**
   (``TestRenderCheckMatchesHandAuthoredShape``) asserts this is
   function/arguments/criticality-identical to what
@@ -117,7 +117,7 @@ class TestRenderCheckMatchesHandAuthoredShape:
         stored_hand_authored = json.loads(inserted_sql[start:end])
 
         # The runner only ever reads these three things off a
-        # dq_quality_rules row: function, arguments, and top-level
+        # dq_resolved_rules row: function, arguments, and top-level
         # criticality. They must match exactly between the registry-
         # materialized row and the equivalent hand-authored one.
         assert materialized_check["check"]["function"] == stored_hand_authored["check"]["function"] == "is_not_null"
@@ -497,8 +497,8 @@ class TestRenderCheckDefinitionFilter:
                 mode="dqx_native",
                 version=version,
                 # Injected value: after substitution the filter becomes
-                # "amount); DROP TABLE dq_quality_rules; -- > 0" (contains DROP).
-                group={"col_a": "amount); DROP TABLE dq_quality_rules; --"},
+                # "amount); DROP TABLE dq_resolved_rules; -- > 0" (contains DROP).
+                group={"col_a": "amount); DROP TABLE dq_resolved_rules; --"},
                 effective_severity="Medium",
                 per_application_tags={},
                 registry_rule_id="r1",
@@ -1198,7 +1198,7 @@ class TestMaterializeBindingBasics:
         written = materializer.materialize_binding("b1")
         assert written == ["ar1-0"]
         insert_sql = sql.execute.call_args_list[0].args[0]
-        assert "INSERT INTO dqx_test.dqx_app_test.dq_quality_rules" in insert_sql
+        assert "INSERT INTO dqx_test.dqx_app_test.dq_resolved_rules" in insert_sql
         assert "'draft'" in insert_sql
         assert "'ar1-0'" in insert_sql
         assert "'registry'" in insert_sql
@@ -1441,7 +1441,7 @@ class TestCleanup:
     def test_removed_application_orphan_is_deleted(self, materializer, sql, registry, monitored_tables):
         # binding now has NO applied rules at all (the application was
         # removed directly from dq_applied_rules), but a stale
-        # dq_quality_rules row from it still exists.
+        # dq_resolved_rules row from it still exists.
         table = MonitoredTable(binding_id="b1", table_fqn="cat.schema.customers", status="draft")
         monitored_tables.get.return_value = MonitoredTableDetail(table=table, applied_rules=[])
 
@@ -1455,7 +1455,7 @@ class TestAllGroupsFailRenderIsNonDestructive:
     follower against a new version whose slots no longer match the follower's
     stored ``column_mapping``, EVERY group fails to render and
     ``_iter_rendered_checks`` returns a non-None EMPTY list. That must NOT be
-    treated as delete-all — the existing approved ``dq_quality_rules`` rows
+    treated as delete-all — the existing approved ``dq_resolved_rules`` rows
     must survive intact (they keep serving; the mismatch surfaces for
     re-review) rather than being wiped.
     """
@@ -1805,7 +1805,7 @@ class TestRenderBindingChecks:
 
     Renders the binding's CURRENT persisted applied-rules state through the
     SAME path materialization uses, but writes NOTHING to
-    ``dq_quality_rules``. For an approved binding with no pending edits the
+    ``dq_resolved_rules``. For an approved binding with no pending edits the
     render equals the materialized output.
     """
 
@@ -1832,7 +1832,7 @@ class TestRenderBindingChecks:
             app_settings=_app_settings_stub(),
         )
         assert checks == [expected]
-        # Read-only: no INSERT/UPDATE/DELETE against dq_quality_rules.
+        # Read-only: no INSERT/UPDATE/DELETE against dq_resolved_rules.
         sql.execute.assert_not_called()
 
     def test_renders_every_mapping_group_across_applied_rules(self, materializer, sql, registry, monitored_tables):
@@ -1957,7 +1957,7 @@ class TestRenderAppliedChecks:
         registry.get_rule.assert_not_called()
         registry.get_version.assert_not_called()
         registry.get_versions_many.assert_called_once_with({("r1", 1)})
-        # Read-only: renders without writing to dq_quality_rules.
+        # Read-only: renders without writing to dq_resolved_rules.
         sql.execute.assert_not_called()
 
     def test_empty_and_idless_refs_render_nothing(self, materializer, registry):

--- a/app/tests/test_monitored_table_service.py
+++ b/app/tests/test_monitored_table_service.py
@@ -923,7 +923,7 @@ def _rollup_dispatch(sql, *, table_status: str, materialized: list[list[str]]) -
             return [_table_row(binding_id="b1", status=table_status)]
         if "FROM dqx_test.dqx_app_test.dq_applied_rules" in query:
             return [["ar1"], ["ar2"]]
-        if "FROM dqx_test.dqx_app_test.dq_quality_rules" in query:
+        if "FROM dqx_test.dqx_app_test.dq_resolved_rules" in query:
             return materialized
         return []
 

--- a/app/tests/test_monitored_table_versions.py
+++ b/app/tests/test_monitored_table_versions.py
@@ -34,7 +34,7 @@ from databricks_labs_dqx_app.backend.services.rules_catalog_service import Rules
 _TABLES = "dqx_test.dqx_app_test.dq_monitored_tables"
 _VERSIONS = "dqx_test.dqx_app_test.dq_monitored_table_versions"
 _APPLIED = "dqx_test.dqx_app_test.dq_applied_rules"
-_QUALITY = "dqx_test.dqx_app_test.dq_quality_rules"
+_QUALITY = "dqx_test.dqx_app_test.dq_resolved_rules"
 
 
 @pytest.fixture

--- a/app/tests/test_monitored_tables_routes.py
+++ b/app/tests/test_monitored_tables_routes.py
@@ -166,7 +166,7 @@ class TestListAndGet:
 
     def test_list_check_count_from_snapshot_for_approved_binding(self):
         # An approved binding (version > 0) reports its frozen snapshot's
-        # check count, NOT the transient live dq_quality_rules count (B2-25).
+        # check count, NOT the transient live dq_resolved_rules count (B2-25).
         svc = MagicMock()
         approved = MonitoredTableSummary(
             table=MonitoredTable(binding_id="b1", table_fqn="cat.schema.tbl", status="approved", version=4),

--- a/app/tests/test_monitored_tables_schema.py
+++ b/app/tests/test_monitored_tables_schema.py
@@ -140,7 +140,7 @@ class TestDqAppliedRules:
 class TestDqQualityRulesProvenance:
     @pytest.mark.parametrize("baseline", _BASELINES)
     def test_provenance_columns_present(self, baseline: str) -> None:
-        cols = _columns(baseline, "dq_quality_rules")
+        cols = _columns(baseline, "dq_resolved_rules")
         assert {"registry_rule_id", "registry_version", "applied_rule_id"} <= cols
 
 

--- a/app/tests/test_pg_executor.py
+++ b/app/tests/test_pg_executor.py
@@ -1780,7 +1780,7 @@ class TestSimpleProperties:
     def test_fqn_returns_two_part_name(self) -> None:
         """Postgres has one catalog per connection — fqn drops the catalog part."""
         e = _make_pg_executor(schema="my_schema")
-        assert e.fqn("dq_quality_rules") == "my_schema.dq_quality_rules"
+        assert e.fqn("dq_resolved_rules") == "my_schema.dq_resolved_rules"
 
     def test_ts_text_is_identity(self) -> None:
         """Postgres lets ``_to_text`` ISO-format the timestamp on the way out."""

--- a/app/tests/test_pg_migration_runner.py
+++ b/app/tests/test_pg_migration_runner.py
@@ -171,18 +171,89 @@ class TestBaselineOnlyCatalogue:
     def test_catalogue_is_exactly_the_baseline(self):
         assert [m.version for m in PG_MIGRATIONS] == [1]
 
-    def test_every_statement_creates_a_table_or_an_index(self):
+    def test_every_statement_creates_a_table_index_or_view(self):
+        # The baseline is CREATE TABLE / CREATE INDEX plus the single
+        # ``dq_rules_core`` compatibility view (CREATE OR REPLACE VIEW) —
+        # still declarative, no ALTER/backfill UPDATE.
         for stmt in _statements(_baseline()):
             assert stmt.startswith(
-                ("CREATE TABLE IF NOT EXISTS", "CREATE INDEX IF NOT EXISTS")
-            ), f"baseline statement is neither a CREATE TABLE nor a CREATE INDEX: {stmt[:120]}"
+                ("CREATE TABLE IF NOT EXISTS", "CREATE INDEX IF NOT EXISTS", "CREATE OR REPLACE VIEW")
+            ), f"unexpected baseline statement kind: {stmt[:120]}"
 
     def test_no_table_is_created_twice(self):
         created = _created_tables(_baseline())
         assert len(created) == len(set(created))
 
     def test_oltp_table_set_is_derived_from_postgres_baseline(self):
+        # The view is not a table and must stay out of OLTP_TABLE_NAMES
+        # (it is never cleared by the reset sweep nor version-tracked).
         assert set(_created_tables(_baseline())) == set(OLTP_TABLE_NAMES)
+        assert "dq_rules_core" not in OLTP_TABLE_NAMES
+
+
+class TestDqRulesCoreView:
+    """The dqx-core-compatible read view over approved ``dq_resolved_rules``."""
+
+    def test_baseline_creates_exactly_one_view(self):
+        views = [s for s in _statements(_baseline()) if s.startswith("CREATE OR REPLACE VIEW")]
+        assert len(views) == 1
+        assert "{schema}.dq_rules_core" in views[0]
+
+    def test_view_exposes_the_columns_dqx_core_reads(self):
+        (view,) = [s for s in _statements(_baseline()) if s.startswith("CREATE OR REPLACE VIEW")]
+        # Column names + order must match dqx-core's LakebaseChecksStorageHandler.
+        for col in (
+            "AS name",
+            "AS criticality",
+            'AS "check"',
+            "AS filter",
+            "AS run_config_name",
+            "AS user_metadata",
+            "AS message_expr",
+            "AS created_at",
+            "AS rule_fingerprint",
+            "AS rule_set_fingerprint",
+        ):
+            assert col in view, f"view is missing projection {col!r}"
+
+    def test_view_only_reads_approved_rows(self):
+        (view,) = [s for s in _statements(_baseline()) if s.startswith("CREATE OR REPLACE VIEW")]
+        assert "WHERE status = 'approved'" in view
+
+    def test_view_maps_run_config_name_to_table_fqn(self):
+        (view,) = [s for s in _statements(_baseline()) if s.startswith("CREATE OR REPLACE VIEW")]
+        assert "a.table_fqn" in view and "AS run_config_name" in view
+
+    def test_set_fingerprint_algorithm_matches_dqx_core(self):
+        # The view computes rule_set_fingerprint as sha256 of the JSON array of
+        # sorted per-rule fingerprints (the set_fp CTE). That must equal
+        # dqx-core's compute_rule_set_fingerprint so external callers see a
+        # value consistent with the core library. This guards against drift
+        # between the SQL reproduction and core's Python for the common
+        # (non-for_each_column) case.
+        import hashlib
+        import json as _json
+
+        from databricks.labs.dqx.rule import compute_rule_fingerprint
+        from databricks.labs.dqx.rule_fingerprint import compute_rule_set_fingerprint_by_metadata
+
+        checks = [
+            {"name": "a", "criticality": "error", "check": {"function": "is_not_null", "arguments": {"column": "id"}}},
+            {
+                "name": "b",
+                "criticality": "warn",
+                "check": {"function": "is_not_null", "arguments": {"column": "email"}},
+            },
+        ]
+        stored_fps = [compute_rule_fingerprint(c) for c in checks]
+        # Python emulation of the view's SQL string_agg:
+        #   '[' || string_agg('"'||fp||'"', ', ' ORDER BY fp) || ']'
+        view_input = "[" + ", ".join(f'"{fp}"' for fp in sorted(stored_fps)) + "]"
+        # (json.dumps(sorted(fps)) renders identically — verified below.)
+        assert view_input == _json.dumps(sorted(stored_fps))
+        view_fp = hashlib.sha256(view_input.encode("utf-8")).hexdigest()
+
+        assert view_fp == compute_rule_set_fingerprint_by_metadata(checks)
 
 
 class TestBaselineShape:

--- a/app/tests/test_registry_rules_routes.py
+++ b/app/tests/test_registry_rules_routes.py
@@ -778,7 +778,7 @@ class TestLifecycleRoutes:
 
     def test_approve_rematerializes_following_applications(self):
         """Publishing a registry rule must propagate to every FOLLOWING
-        (unpinned) application so their materialized ``dq_quality_rules``
+        (unpinned) application so their materialized ``dq_resolved_rules``
         rows pick up the new version (design spec §5)."""
         svc = MagicMock()
         published = _rule(status="approved", version=2)

--- a/app/tests/test_rule_enums.py
+++ b/app/tests/test_rule_enums.py
@@ -79,7 +79,7 @@ def test_service_valid_statuses_derive_from_enum():
 
 def _rules_table_ddl() -> list:
     """The rules-table DDL from the Postgres migration."""
-    pg = next(m.sql for m in PG_MIGRATIONS if "CREATE TABLE" in m.sql and "dq_quality_rules" in m.sql)
+    pg = next(m.sql for m in PG_MIGRATIONS if "CREATE TABLE" in m.sql and "dq_resolved_rules" in m.sql)
     return [pytest.param(pg, id="postgres")]
 
 

--- a/app/tests/test_rules_catalog_service.py
+++ b/app/tests/test_rules_catalog_service.py
@@ -394,3 +394,51 @@ class TestGetHistory:
     def test_swallows_query_error(self, svc):
         svc._sql.query.side_effect = RuntimeError("warehouse down")
         assert svc.get_history("r") == []
+
+
+# ---------------------------------------------------------------------------
+# rule_fingerprint — stored on every write so the dq_rules_core view (and thus
+# DQEngine.load_checks) can read a dqx-core-compatible fingerprint.
+# ---------------------------------------------------------------------------
+
+
+class TestRuleFingerprintPersisted:
+    def test_save_writes_the_dqx_core_fingerprint(self, svc, sql_executor_mock):
+        from databricks.labs.dqx.rule import compute_rule_fingerprint
+
+        # find_duplicates issues one SELECT; no existing rows -> nothing skipped.
+        sql_executor_mock.query.return_value = []
+        check = {
+            "name": "id_not_null",
+            "criticality": "error",
+            "check": {"function": "is_not_null", "arguments": {"column": "id"}},
+        }
+        svc.save("main.sales.orders", [check], user_email="a@b.com")
+
+        insert_sql = sql_executor_mock.execute.call_args_list[0].args[0]
+        assert "rule_fingerprint" in insert_sql
+        # The stored value is exactly what dqx-core would compute for the check.
+        assert compute_rule_fingerprint(check) in insert_sql
+
+    def test_update_rewrites_the_fingerprint(self, svc, sql_executor_mock):
+        from databricks.labs.dqx.rule import compute_rule_fingerprint
+
+        old_check = {
+            "name": "r",
+            "criticality": "error",
+            "check": {"function": "is_not_null", "arguments": {"column": "id"}},
+        }
+        # get_by_rule_id row layout: [table_fqn, check_json, version, status,
+        # created_by, created_at, updated_by, updated_at, source, rule_id].
+        sql_executor_mock.query.return_value = [
+            ["main.sales.orders", json.dumps(old_check), "1", "approved", "a@b.com", "t", "a@b.com", "t", "ui", "rid1"]
+        ]
+        new_check = {
+            "name": "r",
+            "criticality": "error",
+            "check": {"function": "is_not_null", "arguments": {"column": "email"}},
+        }
+        svc.update_rule("rid1", [new_check], user_email="a@b.com")
+
+        update_sql = next(c.args[0] for c in sql_executor_mock.execute.call_args_list if c.args[0].startswith("UPDATE"))
+        assert f"rule_fingerprint = '{compute_rule_fingerprint(new_check)}'" in update_sql

--- a/docs/dqx/docs/installation.mdx
+++ b/docs/dqx/docs/installation.mdx
@@ -441,13 +441,40 @@ Databricks CLI will confirm a few options:
 
 ## DQX Studio installation
 
-[DQX Studio](/docs/studio/) is the no-code Databricks App that exposes DQX's profiling, rule authoring, approval workflow, scheduled runs, and results tracking through a browser. It is deployed to your Databricks workspace as a [Databricks App](https://docs.databricks.com/en/dev-tools/databricks-apps/index.html) using a [Declarative Automation Bundle](https://docs.databricks.com/aws/en/dev-tools/bundles/) (DAB, formerly known as Databricks Asset Bundle).
+[DQX Studio](/docs/studio/) is the no-code Databricks App that exposes DQX's profiling, rule authoring, approval workflow, scheduled runs, and results tracking through a browser. It is deployed to your Databricks workspace as a [Databricks App](https://docs.databricks.com/en/dev-tools/databricks-apps/index.html).
 
-<Admonition type="info" title="Coming soon: Databricks Marketplace">
-We plan to publish DQX Studio to the Databricks Marketplace for one-click installation. Until then, deploy it with the bundle steps below.
+There are two ways to install it:
+
+1. **From the Databricks Marketplace (recommended)** — a one-click install into your workspace, with no local toolchain or repository checkout. Best for most users.
+2. **With a Declarative Automation Bundle (DAB)** — deploy from the source repository with the Databricks CLI. Use this if you can't install from the Marketplace, or you want to customize the bundle.
+
+Both routes deploy the same app and finish in the same in-app **setup wizard**, and both require the workspace-level prerequisites listed under [Prerequisites](#prerequisites-for-installing-dqx-studio) below (Databricks Apps enabled, user token passthrough, serverless compute, a Unity Catalog catalog, and Lakebase Postgres).
+
+### Install DQX Studio from the Databricks Marketplace {#install-dqx-studio-from-the-databricks-marketplace}
+
+The Marketplace listing installs DQX Studio into your workspace as a Databricks App — no repository checkout, `make`, or local build toolchain required. A workspace administrator performs the install.
+
+1. In your Databricks workspace, open **Marketplace** and search for **DQX Studio**. Open the listing and **Get instant access / Install** to add the app to your workspace.
+
+2. When prompted, **bind the three required resources**:
+
+   - a **SQL warehouse** (serverless recommended),
+   - a **Lakebase Postgres endpoint** — required for Studio's application state (rules catalog, app settings, RBAC, comments, schedule configs, scheduler bookkeeping), and
+   - a **Unity Catalog volume** — the bound volume selects Studio's **main catalog and schema**.
+
+3. Make sure a workspace administrator belongs to the workspace group configured as **`DQX_ADMIN_GROUP`** before opening the app — the first admin bootstraps roles for everyone else.
+
+4. **Open the app.** The built-in **setup wizard** checks the resource bindings, creates the required sibling schemas, runs migrations, publishes the task-runner wheels, and explains any Unity Catalog grants that are still needed. It links straight to the Jobs UI for assigning the task-runner's external `run_as` service principal.
+
+Once the wizard reports green, DQX Studio is ready — continue with the [Quickstart](/docs/studio/quickstart).
+
+<Admonition type="info" title="Prefer the bundle?">
+If you can't use the Marketplace, or want to customize the deployment, use the [Declarative Automation Bundle](#install-dqx-studio-using-a-declarative-automation-bundle) route below instead. It deploys the same app.
 </Admonition>
 
-### Prerequisites
+### Prerequisites for installing DQX Studio {#prerequisites-for-installing-dqx-studio}
+
+The workspace-level items below (Databricks Apps, user token passthrough, serverless compute, a Unity Catalog catalog, and Lakebase Postgres) apply to **both** install routes. The **Databricks CLI**, `make`, and **app build toolchain** items apply only to the bundle (DAB) route.
 
 - **Databricks CLI** v1.4.0 or later, authenticated against your workspace (see [Authenticate Databricks CLI](#authenticate-databricks-cli)). v1.4.0 is required for the `postgres_projects` / `postgres_roles` resources; `lifecycle.prevent_destroy` on the studio's stateful schemas / volume / Lakebase project needs only v0.268+.
 - Sufficient workspace permissions to deploy the bundle. **Workspace admin** is the easiest shortcut, but not strictly required — granular per-permission needs (Databricks Apps Can Manage, Lakebase Manager, UC catalog `MANAGE`, service principal `User` role, etc.) are listed in the [DQX Studio deployment guide § Required permissions](https://github.com/databrickslabs/dqx/blob/v0.16.0/app/DEPLOYMENT.md#required-permissions). If you don't hold them yourself, ask an admin to grant them.

--- a/docs/dqx/docs/studio/_category_.json
+++ b/docs/dqx/docs/studio/_category_.json
@@ -1,5 +1,5 @@
 {
-  "label": "DQX Studio (Beta)",
+  "label": "DQX Studio",
   "position": 260,
   "collapsible": true,
   "collapsed": false,

--- a/docs/dqx/docs/studio/authoring/create-a-rule/index.mdx
+++ b/docs/dqx/docs/studio/authoring/create-a-rule/index.mdx
@@ -31,7 +31,7 @@ the **About** tab, where you describe what the rule is. You'll fill in the
 
 Fill in:
 
-- **Name** — a short, human name. Say what good looks like, not what's wrong:
+- **Name** — a short, human readable name. Say what good looks like, not what's wrong:
   *"Email is present"*, not *"email null check"*.
 - **Description** — one line on what the rule checks and why it matters.
 - **Default severity** — how much a failure of this rule matters:
@@ -240,7 +240,7 @@ specific:
 - `signup date can't be in the future`
 - `card last four must be present when payment method is card`
 
-The app reads your description, picks a matching check (or chains a few together),
+The app reads your description, picks a matching rule (or chains a few together),
 and fills in the details — the allowed values, the range, the pattern, and so on.
 
 You can also ask for a specific *type* of rule rather than only describing the

--- a/docs/dqx/docs/studio/index.mdx
+++ b/docs/dqx/docs/studio/index.mdx
@@ -6,9 +6,13 @@ title: DQX Studio
 import Admonition from '@theme/Admonition';
 import ThemedImage from '@theme/ThemedImage';
 import useBaseUrl from '@docusaurus/useBaseUrl';
-import { AvailableSinceVersion, FeatureLifecycleStage, FeatureTags } from '@site/src/components/FeatureTags';
+import { FeatureLifecycleStage, FeatureTags } from '@site/src/components/FeatureTags';
 
 # DQX Studio
+
+<FeatureTags>
+  <FeatureLifecycleStage stage="beta" heading={false} />
+</FeatureTags>
 
 <Admonition type="info" title="Beta">
 DQX Studio is in **Beta**. It's ready to use, but features and screens may still
@@ -49,39 +53,13 @@ data-quality engine, exposed as a Python package.
 
 ## Install DQX Studio
 
-<FeatureTags>
-  <FeatureLifecycleStage stage="beta" heading={false} />
-  <AvailableSinceVersion
-    version="0.1.0"
-    releaseTag="studio-v0.1.0"
-    productName="DQX Studio"
-    heading={false}
-  />
-</FeatureTags>
+Your Databricks administrator installs DQX Studio once for the whole workspace —
+the recommended route is a one-click install from the **Databricks Marketplace**,
+with a **Declarative Automation Bundle (DAB)** available as an alternative. Both
+paths, their prerequisites, and the post-install setup wizard are documented in the
+main installation guide:
 
-Your Databricks administrator can install DQX Studio from Databricks
-Marketplace or deploy it with Declarative Automation Bundles (DABs). DAB
-deployment remains a one-command route and, just like Marketplace, starts
-with the Studio readiness workflow.
-
-Marketplace installation needs three bound resources: a SQL warehouse, a
-Lakebase Postgres endpoint, and a Unity Catalog volume. The bound volume
-chooses Studio's main catalog and schema. An administrator must also belong to
-the workspace group configured as `DQX_ADMIN_GROUP` before opening the app.
-The setup wizard checks the bindings, creates required sibling schemas, runs
-migrations, publishes the task-runner wheels, and explains any grants that are
-still needed. It links to the Jobs UI for assigning the task-runner's external
-`run_as` service principal.
-
-Lakebase is required for Studio's application state. The former Delta-backed
-application state was removed and has no migration path. You can replace a
-bound warehouse today; changing the Lakebase endpoint or volume, and automatic
-task-runner smoke validation, are planned improvements. Marketplace releases
-use published DQX Core pins. Main excludes the compiled Marketplace frontend;
-maintainers generate the complete self-contained artifact on a signed release
-branch from an annotated signed version tag. The local release command signs
-and verifies the branch commit and never pushes it automatically. DAB releases
-continue to use their separate `.build/` output.
+- [DQX Studio installation](/docs/installation#dqx-studio-installation)
 
 For administrator-oriented detail, see the Studio
 [deployment guide](https://github.com/databrickslabs/dqx/blob/v0.16.0/app/DEPLOYMENT.md).
@@ -109,8 +87,8 @@ DQX Studio has three levels that build on each other:
 
 ```mermaid
 flowchart LR
-  A["Rules<br/>(reusable rules)"] -->|apply to a table| B["Tables<br/>(single source of truth<br/>for that table)"]
-  B -->|group related tables| C["Collections<br/>(a data product)"]
+  A["Rules<br/>(reusable rules)"] -->|apply to a table| B["Tables<br/>(source tables the rules<br/>are applied to)"]
+  B -->|group related tables| C["Collections<br/>(e.g. a data product)"]
 ```
 
 1. **Rules Registry** — your library of reusable rule definitions. Write a rule
@@ -119,11 +97,11 @@ flowchart LR
 2. **Monitored table** — a Unity Catalog table you've applied rules to. It's the
    single source of truth for that table's data quality: which rules apply, how
    strict they are, and how it's scoring.
-3. **Collection** — a *data product*: related monitored tables grouped so you can
+3. **Collection** — related monitored tables grouped so you can
    view, run, and schedule them together (for example the `customers`, `orders`,
    and `payments` tables behind one dashboard or Genie space). Collections are
-   optional — reach for them once you have related tables to report on as one
-   product.
+   optional — reach for them once you have related tables to report on (e.g. as
+   one data product).
 
 ### Severity {#severity}
 

--- a/docs/dqx/docs/studio/integrations/_category_.json
+++ b/docs/dqx/docs/studio/integrations/_category_.json
@@ -1,0 +1,1 @@
+{ "label": "Use outside the app", "position": 6, "collapsible": true, "collapsed": true, "link": { "type": "doc", "id": "studio/integrations/index" } }

--- a/docs/dqx/docs/studio/integrations/index.mdx
+++ b/docs/dqx/docs/studio/integrations/index.mdx
@@ -1,0 +1,38 @@
+---
+sidebar_position: 0
+title: Use outside the app
+---
+
+import { FeatureLifecycleStage, FeatureTags } from '@site/src/components/FeatureTags';
+
+# Use DQX Studio data outside the app
+
+<FeatureTags>
+  <FeatureLifecycleStage stage="beta" heading={false} />
+</FeatureTags>
+
+DQX Studio is where you *author, review, and govern* rules — but the rules and
+results it stores are meant to be used by your pipelines too. Studio persists its
+state in your own Unity Catalog catalog, so anything the app knows, your jobs and
+notebooks can read directly.
+
+Two things you'll most often want from outside the app:
+
+- **[Load approved rules](/docs/studio/integrations/load-rules)** — read the rules
+  you approved in Studio into a pipeline with the standard
+  `DQEngine.load_checks` API, and run them wherever your data lives (production
+  included). Studio exposes a dqx-core-compatible view (`dq_rules_core`) for exactly
+  this.
+- **[Read quarantined records](/docs/studio/integrations/read-quarantine)** — query
+  the failing rows Studio's runs captured (`dq_quarantine_records`), for dashboards,
+  alerting, or your own triage.
+
+<div className="admonition admonition-note">
+
+DQX Studio's own runs target dev/UAT data and write results to the app's catalog —
+they are **not** intended to run rules as part of your production pipelines. To run
+Studio-authored rules against production data, load them with
+[`DQEngine.load_checks`](/docs/studio/integrations/load-rules) from your own
+pipeline.
+
+</div>

--- a/docs/dqx/docs/studio/integrations/load-rules.mdx
+++ b/docs/dqx/docs/studio/integrations/load-rules.mdx
@@ -84,15 +84,62 @@ ORDER BY run_config_name;
 ```
 </Admonition>
 
+## Grant access to the view
+
+`dq_rules_core` lives in Studio's **Lakebase Postgres** schema, so access is **not**
+automatic — a reader outside the app (an engineer, or a pipeline's service
+principal) needs a Studio/Lakebase administrator to grant **two** things:
+
+1. **Access to the Lakebase database instance.** To open a connection,
+   `load_checks` mints a short-lived Postgres credential from Databricks for
+   Studio's Lakebase instance. The reader's Databricks identity must be allowed to
+   use that database instance (grant it on the instance in Databricks). Without
+   this, the connection can't be established.
+
+2. **A Postgres `SELECT` on the view.** The Postgres role mapped to the reader's
+   Databricks identity needs `USAGE` on the schema and `SELECT` on the view. An
+   administrator (or the Studio app's owning superuser role) runs, against the
+   Lakebase database:
+
+   ```sql
+   GRANT USAGE  ON SCHEMA dqx_studio          TO "<principal>";
+   GRANT SELECT ON dqx_studio.dq_rules_core   TO "<principal>";
+   ```
+
+   `<principal>` is the Postgres role for the reader's identity — for a service
+   principal, its **application id**. Granting `SELECT` on the view is enough;
+   readers do **not** need access to the underlying `dq_resolved_rules` table.
+
+For a **service principal** reader, pass its id as `client_id` so the connection
+authenticates as that SP:
+
+```python
+LakebaseChecksStorageConfig(
+    location="databricks_postgres.dqx_studio.dq_rules_core",
+    instance_name="<your-lakebase-instance>",
+    client_id="<service-principal-application-id>",
+    run_config_name="main.sales.orders",
+)
+```
+
+<Admonition type="tip" title="Least privilege">
+Grant read access only to the principals that actually run the rules, and only
+`SELECT` on `dq_rules_core` — never broader write access to Studio's schema.
+</Admonition>
+
 ## Notes and limits
 
 - **Approved only.** The view excludes drafts and rejected rules by design. Approve
   a rule in Studio before a pipeline can load it.
-- **Fingerprints.** `rule_fingerprint` is dqx-core's per-rule hash and matches what
-  the library computes. `rule_set_fingerprint` is computed over a table's approved
-  set so the loader can pick the current version; for rule sets that use
-  `for_each_column`, this value may differ from a value core computes by expanding
-  the fan-out — it never affects *which* rules load, only the informational
-  fingerprint.
+- **Fingerprints.** `rule_fingerprint` is dqx-core's `compute_rule_fingerprint` of
+  the **stored** check. `rule_set_fingerprint` is computed over a table's approved
+  set so the loader can pick the current version. For rules that use
+  `for_each_column`, Studio stores the *compact* (un-expanded) check, so both
+  fingerprints are taken over that compact form and may differ from values dqx-core
+  computes by expanding the fan-out first — this never affects *which* rules load,
+  only the informational fingerprint values.
 - **Read-only.** `dq_rules_core` is a view. Author and manage rules in the app;
   pipelines only read.
+- **Availability.** The view ships with recent DQX Studio versions. If a workspace
+  was installed before it existed, an administrator re-provisions Studio's schema so
+  the view (and the `rule_fingerprint` column it reads) are created.

--- a/docs/dqx/docs/studio/integrations/load-rules.mdx
+++ b/docs/dqx/docs/studio/integrations/load-rules.mdx
@@ -1,0 +1,98 @@
+---
+sidebar_position: 1
+title: Load rules outside the app
+---
+
+import Admonition from '@theme/Admonition';
+import { FeatureLifecycleStage, FeatureTags } from '@site/src/components/FeatureTags';
+
+# Load Studio rules outside the app
+
+<FeatureTags>
+  <FeatureLifecycleStage stage="beta" heading={false} />
+</FeatureTags>
+
+Rules you approve in DQX Studio can be loaded and run by any PySpark pipeline
+using the standard [DQX Core](/docs/guide/) API — no export step, no copy-paste.
+Studio publishes a **dqx-core-compatible view**, `dq_rules_core`, over its approved
+rules, and `DQEngine.load_checks` reads it directly.
+
+## The `dq_rules_core` view
+
+Studio stores each authored rule as a row in its internal `dq_resolved_rules`
+table. That table carries Studio-specific columns (lifecycle status, versioning,
+provenance) that dqx-core doesn't understand. The **`dq_rules_core`** view reshapes
+the **approved** rules into exactly the columns dqx-core's Lakebase reader expects:
+
+| View column | Meaning |
+| ----------- | ------- |
+| `name`, `criticality`, `filter` | The check's identity and severity. |
+| `check` | The inner `{function, arguments}` (and `for_each_column` when used). |
+| `run_config_name` | **The fully-qualified table the rule applies to** (`table_fqn`). |
+| `user_metadata` | Any tags/labels attached to the rule. |
+| `rule_fingerprint`, `rule_set_fingerprint` | dqx-core fingerprints (used to select the current rule set). |
+
+Only rules at status **`approved`** appear in the view — drafts and rejected rules
+are never loaded.
+
+<Admonition type="info" title="run_config_name is the table FQN">
+Studio groups rules by the table they apply to, so the view maps
+`run_config_name` to that table's fully-qualified name (for example
+`main.sales.orders`). Cross-table SQL checks, which have no single home table,
+appear under a synthetic `run_config_name` of the form <code>__sql_check__/&lt;name&gt;</code>.
+</Admonition>
+
+## Load approved rules
+
+Point `LakebaseChecksStorageConfig` at the view and pass the table you want the
+rules for as `run_config_name`:
+
+```python
+from databricks.sdk import WorkspaceClient
+from databricks.labs.dqx.engine import DQEngine
+from databricks.labs.dqx.config import LakebaseChecksStorageConfig
+
+engine = DQEngine(WorkspaceClient())
+
+checks = engine.load_checks(
+    LakebaseChecksStorageConfig(
+        # <lakebase-database>.<studio-schema>.dq_rules_core
+        location="databricks_postgres.dqx_studio.dq_rules_core",
+        instance_name="<your-lakebase-instance>",   # Studio's Lakebase instance
+        run_config_name="main.sales.orders",         # the table the rules apply to
+    )
+)
+
+# Run the Studio-authored rules against your own DataFrame
+checked_df = engine.apply_checks_by_metadata(df, checks)
+
+# ...or split valid rows from quarantined ones
+valid_df, quarantined_df = engine.apply_checks_by_metadata_and_split(df, checks)
+```
+
+With no `rule_set_fingerprint` given, the loader returns the **current** approved
+rule set for the table. All approved rules for a table share one
+`rule_set_fingerprint`, so you always get the complete set, not a single rule.
+
+<Admonition type="tip" title="Which tables have approved rules?">
+List the loadable `run_config_name` values with a quick query against the view:
+
+```sql
+SELECT DISTINCT run_config_name
+FROM dqx_studio.dq_rules_core
+ORDER BY run_config_name;
+```
+</Admonition>
+
+## Notes and limits
+
+- **Approved only.** The view excludes drafts and rejected rules by design. Approve
+  a rule in Studio before a pipeline can load it.
+- **Fingerprints.** `rule_fingerprint` is dqx-core's per-rule hash and matches what
+  the library computes. `rule_set_fingerprint` is computed over a table's approved
+  set so the loader can pick the current version; for rule sets that use
+  `for_each_column`, this value may differ from a value core computes by expanding
+  the fan-out — it never affects *which* rules load, only the informational
+  fingerprint.
+- **Read-only.** `dq_rules_core` is a view. Author and manage rules in the app;
+  pipelines only read.

--- a/docs/dqx/docs/studio/integrations/read-quarantine.mdx
+++ b/docs/dqx/docs/studio/integrations/read-quarantine.mdx
@@ -1,0 +1,122 @@
+---
+sidebar_position: 2
+title: Read quarantined records
+---
+
+import Admonition from '@theme/Admonition';
+import { FeatureLifecycleStage, FeatureTags } from '@site/src/components/FeatureTags';
+
+# Read quarantined records outside the app
+
+<FeatureTags>
+  <FeatureLifecycleStage stage="beta" heading={false} />
+</FeatureTags>
+
+When a DQX Studio run finds failing rows, it copies a **sample** of them into a
+Delta table called `dq_quarantine_records` so you can inspect what went wrong. The
+app's [Results](/docs/studio/running/#investigate-and-act-on-a-failure) view reads
+this table, but it's a plain Delta table in your own catalog — you can query it
+directly from SQL, a notebook, a dashboard, or an alerting job.
+
+<Admonition type="warning" title="It holds source-row data">
+Each quarantined record includes the **full source row** that failed
+(`row_data`), so the table is a potential PII surface. It lives in your catalog and
+is governed by Unity Catalog — grant access accordingly. Records are a **sample**,
+not every failing row, and are retained for `quarantine_retention_days` (default
+**30 days**) before the app's retention sweep deletes them.
+</Admonition>
+
+## Where it lives
+
+The table is in the Studio schema of the catalog you selected at install:
+
+```
+<catalog>.dqx_studio.dq_quarantine_records
+```
+
+## Schema
+
+| Column | Type | Description |
+| ------ | ---- | ----------- |
+| `quarantine_id` | `STRING` | Primary key for the quarantined row. |
+| `run_id` | `STRING` | The run that captured it — join to `dq_validation_runs`. |
+| `source_table_fqn` | `STRING` | Fully-qualified name of the table the row came from. |
+| `requesting_user` | `STRING` | Who triggered the run. |
+| `row_data` | `VARIANT` | The full source row, as a JSON object. |
+| `errors` | `VARIANT` | Array of the **error**-severity checks the row failed. |
+| `warnings` | `VARIANT` | Array of the **warn**-severity checks the row failed. |
+| `created_at` | `TIMESTAMP` | When the record was written. |
+
+Each element of `errors` / `warnings` is the standard DQX result payload — the
+same shape as the `_errors` / `_warnings` columns in
+[DQX Core](/docs/guide/additional_configuration#customizing-result-columns): `name`, `message`,
+`columns`, `filter`, `function`, `run_time`, `user_metadata`, and the rule
+fingerprints.
+
+## Query it
+
+Replace `<catalog>` with your Studio catalog.
+
+**Recent quarantined rows for a table:**
+
+```sql
+SELECT quarantine_id, run_id, created_at, row_data, errors, warnings
+FROM <catalog>.dqx_studio.dq_quarantine_records
+WHERE source_table_fqn = 'main.sales.orders'
+ORDER BY created_at DESC
+LIMIT 100;
+```
+
+**Read fields out of the source row** — `VARIANT` supports path access with `:` and
+casts with `::`:
+
+```sql
+SELECT quarantine_id,
+       row_data:order_id::string   AS order_id,
+       row_data:amount::double     AS amount
+FROM <catalog>.dqx_studio.dq_quarantine_records
+WHERE source_table_fqn = 'main.sales.orders';
+```
+
+**One row per failed check** — explode the `errors` array so each failed check
+becomes its own row:
+
+```sql
+SELECT q.quarantine_id,
+       q.source_table_fqn,
+       e.value:name::string     AS check_name,
+       e.value:message::string  AS message,
+       e.value:columns          AS columns
+FROM <catalog>.dqx_studio.dq_quarantine_records AS q,
+     LATERAL variant_explode(q.errors) AS e
+WHERE q.run_id = '<run_id>';
+```
+
+**Count failures by check across a run** (a quick "what's failing most?"):
+
+```sql
+SELECT e.value:name::string AS check_name, count(*) AS failing_rows
+FROM <catalog>.dqx_studio.dq_quarantine_records AS q,
+     LATERAL variant_explode(q.errors) AS e
+WHERE q.source_table_fqn = 'main.sales.orders'
+GROUP BY e.value:name::string
+ORDER BY failing_rows DESC;
+```
+
+**Join to run metadata** in `dq_validation_runs` (run timing, trigger, status):
+
+```sql
+SELECT q.quarantine_id, q.source_table_fqn, q.created_at, r.*
+FROM <catalog>.dqx_studio.dq_quarantine_records AS q
+JOIN <catalog>.dqx_studio.dq_validation_runs   AS r
+  ON q.run_id = r.run_id
+WHERE q.source_table_fqn = 'main.sales.orders'
+ORDER BY q.created_at DESC;
+```
+
+<Admonition type="tip" title="Reading VARIANT columns">
+`row_data`, `errors`, and `warnings` are Databricks
+[`VARIANT`](https://docs.databricks.com/aws/en/semi-structured/variant) columns.
+Use `col:field` to navigate, `::type` to cast, and `variant_explode()` to turn a
+`VARIANT` array into rows.
+</Admonition>

--- a/docs/dqx/docusaurus.config.ts
+++ b/docs/dqx/docusaurus.config.ts
@@ -134,7 +134,7 @@ const config: Config = {
             },
             {
               id: 'dqx-studio',
-              name: 'DQX Studio (Beta)',
+              name: 'DQX Studio',
               description: 'The no-code web app for authoring, reviewing, running, and monitoring data quality rules',
               position: 3,
               routes: [

--- a/docs/dqx/src/pages/index.tsx
+++ b/docs/dqx/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Button from '../components/Button';
 import {
   AppWindow, Code, Sparkles, BarChart2, ShieldCheck, LineChart, ScrollText,
   Boxes, Store, ArrowRight, Library,
-  Info, FileText, Activity, AlertTriangle, Grid, PieChart, Radar, Calculator,
+  Info, FileText, Activity, AlertTriangle, Grid, PieChart, Radar,
   Bell, BotMessageSquare,
 } from 'lucide-react';
 
@@ -41,7 +41,7 @@ const Hero = (): JSX.Element => {
             notebooks — batch and streaming.
           </p>
           <span className="inline-flex items-center gap-1.5 rounded-full bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300 text-xs font-semibold px-2.5 py-1 mb-3">
-            Used by 700+ Databricks customers
+            Battle-tested data quality framework
           </span>
           <span className="text-blue-600 dark:text-blue-400 text-sm font-medium inline-flex items-center gap-1 mt-auto">
             Open the Core guide
@@ -94,11 +94,17 @@ const coreFeatures = [
 
 const studioFeatures = [
   { title: 'Reusable rules repository', description: 'Build reusable checks in low code, with a built-in AI assistant.', icon: Library, link: '/docs/studio/authoring/create-a-rule' },
+  { title: 'Row & column-level rules', description: 'Define quality rules at both the row and column level.', icon: Grid, link: '/docs/studio/authoring/create-a-rule' },
+  { title: 'Rich failure detail', description: 'Drill into exactly which rows failed and why, right down to the failing records.', icon: Info, link: '/docs/studio/running/' },
+  { title: 'Custom reactions to failures', description: 'Set pass thresholds and severities to decide what a failure means and how to triage it.', icon: AlertTriangle, link: '/docs/studio/monitoring/assign-rules' },
+  { title: 'Profiling & rule generation', description: 'Point the app at a table to profile it and auto-generate tailored rule candidates.', icon: PieChart, link: '/docs/studio/monitoring/profiling' },
+  { title: 'Data contracts support', description: 'Generate quality rules from ODCS data contracts, schema validation included.', icon: ScrollText, link: '/docs/studio/authoring/import-rules' },
   { title: 'Monitor tables & thresholds', description: 'Apply rules to tables, set pass thresholds, and improve quality gradually.', icon: BarChart2, link: '/docs/studio/monitoring/assign-rules' },
   { title: 'Suggest rules with AI', description: 'Point the app at a table and it proposes a tailored set of checks for its columns and data.', icon: Sparkles, link: '/docs/studio/monitoring/assign-rules#suggest-rules-with-ai' },
   { title: 'Data products with Collections', description: 'Group related tables into a data product and see quality across all of them at once.', icon: Boxes, link: '/docs/studio/monitoring/collections' },
   { title: 'Results & drill-down', description: 'Follow the score down by dimension, severity, rule, and table — all the way to the failing rows.', icon: LineChart, link: '/docs/studio/running/' },
   { title: 'Governed by design', description: 'Four-eyes approvals, roles, audit trails, and access that respects Unity Catalog.', icon: ShieldCheck, link: '/docs/studio/governance/approval-workflow' },
+  { title: 'Marketplace-based installation', description: 'A one-click installation into your workspace using the Databricks Marketplace — no manual deployment steps.', icon: Store, link: '/docs/installation#dqx-studio-installation' },
 ];
 
 const FeatureTabs = ({ tab, setTab }: { tab: 'core' | 'studio'; setTab: (t: 'core' | 'studio') => void }): JSX.Element => {
@@ -199,82 +205,6 @@ const FeatureTabs = ({ tab, setTab }: { tab: 'core' | 'studio'; setTab: (t: 'cor
   );
 };
 
-const Marketplace = (): JSX.Element => {
-  return (
-    <div className="px-4 md:px-10 py-12 w-full">
-      <div className="max-w-5xl mx-auto rounded-2xl border border-dashed border-purple-300 dark:border-purple-800/60 bg-gradient-to-br from-purple-50 to-blue-50 dark:from-purple-950/20 dark:to-blue-950/20 p-8 md:p-12 text-center">
-        <span className="inline-flex items-center gap-2 rounded-full bg-purple-100 dark:bg-purple-900/40 text-purple-700 dark:text-purple-300 text-xs font-semibold px-3 py-1 mb-4">
-          <Store className="w-3.5 h-3.5" /> COMING SOON
-        </span>
-        <h2 className="text-2xl md:text-3xl font-semibold mb-3">
-          DQX Studio on the Databricks Marketplace
-        </h2>
-        <p className="text-gray-600 dark:text-gray-400 max-w-2xl mx-auto text-balance">
-          A one-click listing on the Databricks Marketplace to install DQX Studio into
-          your workspace — no manual deployment steps. We’re working on it.
-        </p>
-      </div>
-    </div>
-  );
-};
-
-const CostCalculator = (): JSX.Element => {
-  // Placeholder inputs — the calculator itself is not wired up yet.
-  const inputs = [
-    { label: 'Table size', value: '250 GB', min: '1 GB', max: '10 TB' },
-    { label: 'Results views per user per day', value: '20', min: '1', max: '200' },
-    { label: 'Number of users', value: '50', min: '1', max: '1,000' },
-  ];
-
-  return (
-    <div className="px-4 md:px-10 py-12 w-full">
-      <div className="max-w-5xl mx-auto rounded-2xl border border-dashed border-emerald-300 dark:border-emerald-800/60 bg-gradient-to-br from-emerald-50 to-teal-50 dark:from-emerald-950/20 dark:to-teal-950/20 p-8 md:p-12">
-        <div className="text-center">
-          <span className="inline-flex items-center gap-2 rounded-full bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300 text-xs font-semibold px-3 py-1 mb-4">
-            <Calculator className="w-3.5 h-3.5" /> COMING SOON
-          </span>
-          <h2 className="text-2xl md:text-3xl font-semibold mb-3">
-            Cost Calculator
-          </h2>
-          <p className="text-gray-600 dark:text-gray-400 max-w-2xl mx-auto text-balance mb-8">
-            Estimate what running DQX Studio will cost for your workspace. Set your
-            table size, how often people look at results, and how many users you
-            have — we’ll do the maths. We’re working on it.
-          </p>
-        </div>
-
-        {/* Preview of the inputs — disabled until the calculator ships */}
-        <div
-          className="max-w-2xl mx-auto flex flex-col gap-6 opacity-60 select-none pointer-events-none"
-          aria-hidden="true"
-        >
-          {inputs.map((input, i) => (
-            <div key={i}>
-              <div className="flex items-baseline justify-between mb-2">
-                <span className="text-sm font-medium text-gray-900 dark:text-white">{input.label}</span>
-                <span className="text-sm font-semibold text-emerald-700 dark:text-emerald-300">{input.value}</span>
-              </div>
-              <input
-                type="range"
-                disabled
-                readOnly
-                min={0}
-                max={100}
-                defaultValue={i === 0 ? 30 : i === 1 ? 45 : 55}
-                className="w-full accent-emerald-500 cursor-not-allowed"
-              />
-              <div className="flex justify-between text-xs text-gray-500 dark:text-gray-500 mt-1">
-                <span>{input.min}</span>
-                <span>{input.max}</span>
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
-    </div>
-  );
-};
-
 export default function Home(): JSX.Element {
   const [tab, setTab] = useState<'core' | 'studio'>('core');
   return (
@@ -283,12 +213,6 @@ export default function Home(): JSX.Element {
         <div className="flex flex-col items-center mx-auto w-full max-w-screen-xl">
           <Hero />
           <FeatureTabs tab={tab} setTab={setTab} />
-          {tab === 'studio' && (
-            <>
-              <Marketplace />
-              <CostCalculator />
-            </>
-          )}
         </div>
       </main>
     </Layout>


### PR DESCRIPTION
## What & why

Lets external pipelines load DQX Studio-authored rules with the standard `DQEngine.load_checks` API, and makes the Studio storage table names clearer.

### 1. `dq_rules_core` compatibility view
A dqx-core-compatible read view over **approved** rules in `dq_resolved_rules`, so pipelines can load Studio rules with unmodified core:

```python
engine.load_checks(LakebaseChecksStorageConfig(
    location="databricks_postgres.dqx_studio.dq_rules_core",
    instance_name="<lakebase-instance>",
    run_config_name="<table_fqn>"))
```

`run_config_name ← table_fqn`; the inner `{function, arguments}` is extracted from the stored JSONB; only `status = 'approved'` rows appear.

### 2. Fingerprints
- `rule_fingerprint` (dqx-core `compute_rule_fingerprint`) is stored on **every** write path into the table (`RulesCatalogService.save` / `update_rule`, `Materializer`).
- `rule_set_fingerprint` is computed **in the view** per `table_fqn` (a GROUP BY over the approved set) so `load_checks` selects the current set and returns all of it. A parity test guards that the SQL reproduction matches core's Python.

### 3. Rename `dq_quality_rules` → `dq_resolved_rules`
Includes `dq_quality_rules_history` → `dq_resolved_rules_history`, indexes, and constraints — edited into the v1 Postgres baseline in place (per the single-baseline convention; existing dev deployments re-provision). All backend, UI, test, and regenerated `api.ts` references updated.

### 4. Docs
- New **"Use outside the app"** Studio section: load rules via `LakebaseChecksStorageConfig`; read `dq_quarantine_records` (schema + example queries).
- Front page: hero → "Battle-tested data quality framework", expanded Studio capability list, removed the placeholder Marketplace/Cost Calculator banners, **DQX Studio** section renamed with a proper `<FeatureTags>` Beta tag.
- Installation guide: Marketplace made the **recommended** install path (Studio index links to it).
- Wording fixes (Collections/Tables labels, "human readable name").

## Testing
- 4157 backend tests pass · basedpyright 0 errors · tsc clean · 837 UI tests · docs build + tests pass.